### PR TITLE
Color Temperature of None

### DIFF
--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -62,6 +62,8 @@ def _brightness_to_hubspace(value):
 def _convert_color_temp(value):
         if isinstance(value, str) and value.endswith('K'):
             value = value[:-1]
+        if value is None:
+            value = 1
         return 1000000 // int(value)
 
 def _add_entity(entities, hs, model, deviceClass, friendlyName, debug):


### PR DESCRIPTION
If color temperature is None, set a value of 1 (which will convert to 1000000 mired / Kelvin).

Useful if asking for the color temperature of a fan component in a combo where the light supports color temperature.

Suggested fix for #16 .