### PR TITLE
Automatic discovery

### DIFF
--- a/custom_components/hubspace/hubspace.py
+++ b/custom_components/hubspace/hubspace.py
@@ -261,6 +261,26 @@ class HubSpace:
         #_LOGGER.debug("No model found ")
         return child,model,deviceId,deviceClass
 
+    def discoverDeviceIds(self):
+        response = self.getMetadeviceInfo()
+                
+        for lis in response.json():
+            if lis.get('typeId') == 'metadevice.device':
+                child = lis.get('id')
+                deviceId = lis.get('deviceId')
+                model = lis.get('description', {}).get('device', {}).get('model')
+                deviceClass = lis.get('description', {}).get('device', {}).get('deviceClass')
+                friendlyName = lis.get('friendlyName')
+                yield child, model, deviceId, deviceClass, friendlyName
+
+    def getFunctions(self, deviceId, functionClass):
+        response = self.getMetadeviceInfo()
+        
+        for lis in response.json():
+            if lis.get('deviceId') == deviceId:
+                for function in lis.get('description', {}).get('functions', []):
+                    if function.get('functionClass') == functionClass:
+                        yield function
 
     def getState(self,child,desiredStateName):
 

--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -162,7 +162,7 @@ def setup_platform(
                     try:
                         _LOGGER.debug(f"Found toggle with id {toggle.get('id')} and instance {toggle.get('functionInstance')}")
                         outletIndex = toggle.get('functionInstance').split('-')[1]
-                        entities.append(HubspaceOutlet(hs, friendlyName, outletIndex, debug, childId, model, deviceId, deviceClass)
+                        entities.append(HubspaceOutlet(hs, friendlyName, outletIndex, debug, childId, model, deviceId, deviceClass))
                     except IndexError:
                         _LOGGER.debug('Error extracting outlet index')
             # TODO: Add support for Transformer device here: need a log to determine the deviceClass
@@ -172,7 +172,7 @@ def setup_platform(
                     try:
                         _LOGGER.debug(f"Found toggle with id {toggle.get('id')} and instance {toggle.get('functionInstance')}")
                         outletIndex = toggle.get('functionInstance').split('-')[1]
-                        entities.append(HubspaceTransformer(hs, friendlyName, outletIndex, debug, childId, model, deviceId, deviceClass)
+                        entities.append(HubspaceTransformer(hs, friendlyName, outletIndex, debug, childId, model, deviceId, deviceClass))
                     except IndexError:
                         _LOGGER.debug('Error extracting outlet index')
             '''

--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -143,6 +143,40 @@ def setup_platform(
 
             entities = _add_entity(entities, hs, model, deviceClass, friendlyName, debug)
     
+    if config.get(CONF_FRIENDLYNAMES) == [] and config.get(CONF_ROOMNAMES) == []:
+        _LOGGER.debug('Attempting automatic discovery')
+        for [childId, model, deviceId, deviceClass, friendlyName] in hs.discoverDeviceIds():
+            _LOGGER.debug("childId " + childId )
+            _LOGGER.debug("Switch on Model " + model )
+            _LOGGER.debug("deviceId: " + deviceId )
+            _LOGGER.debug("deviceClass: " + deviceClass )
+            _LOGGER.debug("friendlyName: " + friendlyName )
+            
+            entities = _add_entity(entities, hs, model, deviceClass, friendlyName, debug)
+            if deviceClass == 'fan':
+                entities.append(HubspaceFan(hs, friendlyName, debug, childId, model, deviceId, deviceClass))
+            elif deviceClass == 'light':
+                entities.append(HubspaceLight(hs, friendlyName, debug, childId, model, deviceId, deviceClass))
+            elif deviceClass == 'power-outlet':
+                for toggle in hs.getFunctions(childId, 'toggle'):
+                    try:
+                        _LOGGER.debug(f"Found toggle with id {toggle.get('id')} and instance {toggle.get('functionInstance')}")
+                        outletIndex = toggle.get('functionInstance').split('-')[1]
+                        entities.append(HubspaceOutlet(hs, friendlyName, outletIndex, debug, childId, model, deviceId, deviceClass)
+                    except IndexError:
+                        _LOGGER.debug('Error extracting outlet index')
+            # TODO: Add support for Transformer device here: need a log to determine the deviceClass
+            '''
+            elif deviceClass == 'power-transformer???'
+                for toggle in hs.getFunctions(childId, 'toggle'):
+                    try:
+                        _LOGGER.debug(f"Found toggle with id {toggle.get('id')} and instance {toggle.get('functionInstance')}")
+                        outletIndex = toggle.get('functionInstance').split('-')[1]
+                        entities.append(HubspaceTransformer(hs, friendlyName, outletIndex, debug, childId, model, deviceId, deviceClass)
+                    except IndexError:
+                        _LOGGER.debug('Error extracting outlet index')
+            '''
+    
     if not entities:
         return
     add_entities(entities, True)
@@ -162,7 +196,7 @@ def setup_platform(
 class HubspaceLight(LightEntity):
     """Representation of an Awesome Light."""
     
-    def __init__(self, hs, friendlyname,debug) -> None:
+    def __init__(self, hs, friendlyname, debug, childId = None, model = None, deviceId = None, deviceClass = None) -> None:
         """Initialize an AwesomeLight."""
         
         _LOGGER.debug("Light Name: " )
@@ -172,12 +206,12 @@ class HubspaceLight(LightEntity):
         
         self._debug = debug
         self._state = 'off'
-        self._childId = None
-        self._model = None
+        self._childId = childId
+        self._model = model
         self._brightness = None
         self._usePowerFunctionInstance = None
         self._hs = hs
-        self._deviceId = None
+        self._deviceId = deviceId
         self._debugInfo = None
 
         # colorMode == 'color' || 'white' 
@@ -188,8 +222,8 @@ class HubspaceLight(LightEntity):
         self._rgbColor = None
         self._temperature_choices = None
         self._temperature_suffix = None
-        deviceClass = None
-        [self._childId, self._model, self._deviceId,deviceClass] = self._hs.getChildId(self._name)
+        if None in (childId, model, deviceId, deviceClass):
+            [self._childId, self._model, self._deviceId, deviceClass] = self._hs.getChildId(self._name)
 
         self._supported_color_modes = []
 
@@ -217,11 +251,26 @@ class HubspaceLight(LightEntity):
         #fan
         if self._model == '52133, 37833' or self._model == '76278, 37278':
             self._usePowerFunctionInstance = 'light-power'
-            self._supported_color_modes.extend([ColorMode.BRIGHTNESS, ColorMode.COLOR_TEMP, ColorMode.WHITE])
-            self._max_mireds = 371
-            self._min_mireds = 153
-            self._temperature_choices = (2700, 3000, 3500, 4000, 5000, 6500)
+            self._supported_color_modes.extend([ColorMode.BRIGHTNESS])
             self._temperature_suffix = 'K'
+            self._temperature_choices = []
+            for colorTemperature in self._hs.getFunctions(self._deviceId, 'color-temperature'):
+                for value in colorTemperature.get('values'):
+                    temperatureName = value.get('name')
+                    if isinstance(temperatureName, str) and temperatureName.endswith(self._temperature_suffix):
+                        try:
+                            temperatureValue = int(temperatureName[:-len(self._temperature_suffix)])
+                        except ValueError:
+                            _LOGGER.debug(f"Can't convert temperatureName {temperatureName} to int")
+                            temperatureValue = None
+                        if temperatureValue is not None and temperatureValue not in self._temperature_choices:
+                            self._temperature_choices.append(temperatureValue)
+            if len(self._temperature_choices):
+                self._supported_color_modes.extend([ColorMode.COLOR_TEMP, ColorMode.WHITE])
+                self._max_mireds = 1000000//min(self._temperature_choices) + 1
+                self._min_mireds = 1000000//max(self._temperature_choices)
+            else:
+                self._temperature_choices = None
 
         # https://www.homedepot.com/p/Commercial-Electric-5-in-6-in-Smart-Hubspace-Color-Selectable-CCT-Integrated-LED-Recessed-Light-Trim-Works-with-Amazon-Alexa-and-Google-538561010/314254248
         if self._model == '538551010, 538561010, 538552010, 538562010':
@@ -369,23 +418,24 @@ class HubspaceOutlet(LightEntity):
     
     
     
-    def __init__(self, hs, friendlyname,outletIndex,debug) -> None:
+    def __init__(self, hs, friendlyname, outletIndex, debug, childId = None, model = None, deviceId = None, deviceClass = None) -> None:
         """Initialize an AwesomeLight."""
         
         self._name = friendlyname + "_outlet_" + outletIndex 
         
         self._debug = debug
         self._state = 'off'
-        self._childId = None
-        self._model = None
+        self._childId = childId
+        self._model = model
         self._brightness = None
         self._usePrimaryFunctionInstance = False
         self._hs = hs
-        self._deviceId = None
+        self._deviceId = deviceId
         self._debugInfo = None
         self._outletIndex = outletIndex
-        deviceClass = None
-        [self._childId, self._model, self._deviceId,deviceClass] = self._hs.getChildId(friendlyname)
+
+        if None in (childId, model, deviceId, deviceClass):
+            [self._childId, self._model, self._deviceId, deviceClass] = self._hs.getChildId(friendlyname)
     
     @property
     def name(self) -> str:
@@ -451,23 +501,26 @@ class HubspaceFan(LightEntity):
     """Representation of an Awesome Light."""
     
         
-    def __init__(self, hs, friendlyname, debug) -> None:
+    def __init__(self, hs, friendlyname, debug, childId = None, model = None, deviceId = None, deviceClass = None) -> None:
         """Initialize an AwesomeLight."""
         
-        self._name = friendlyname + "_fan" 
+        if None in (childId, model, deviceId, deviceClass):
+            self._name = friendlyname + "_fan" 
+        else:
+            self._name = friendlyname
         
         self._debug = debug
         self._state = 'off'
-        self._childId = None
-        self._model = None
+        self._childId = childId
+        self._model = model
         self._brightness = None
         self._usePrimaryFunctionInstance = False
         self._hs = hs
-        self._deviceId = None
+        self._deviceId = deviceId
         self._debugInfo = None
         
-        deviceClass = None
-        [self._childId, self._model, self._deviceId,deviceClass] = self._hs.getChildId(friendlyname)
+        if None in (childId, model, deviceId, deviceClass):
+            [self._childId, self._model, self._deviceId, deviceClass] = self._hs.getChildId(friendlyname)
     
     @property
     def name(self) -> str:
@@ -570,26 +623,26 @@ class HubspaceTransformer(LightEntity):
     
     
     
-    def __init__(self, hs, friendlyname,outletIndex,debug) -> None:
+    def __init__(self, hs, friendlyname, outletIndex, debug, childId = None, model = None, deviceId = None, deviceClass = None) -> None:
         """Initialize an AwesomeLight."""
         
         self._name = friendlyname + "_transformer_" + outletIndex 
         
         self._debug = debug
         self._state = 'off'
-        self._childId = None
-        self._model = None
+        self._childId = childId
+        self._model = model
         self._brightness = None
         self._usePrimaryFunctionInstance = False
         self._hs = hs
-        self._deviceId = None
+        self._deviceId = deviceId
         self._debugInfo = None
         self._watts = None
         self._volts = None
         
         self._outletIndex = outletIndex
-        deviceClass = None
-        [self._childId, self._model, self._deviceId,deviceClass] = self._hs.getChildId(friendlyname)
+        if None in (childId, model, deviceId, deviceClass):
+            [self._childId, self._model, self._deviceId, deviceClass] = self._hs.getChildId(friendlyname)
     
     @property
     def name(self) -> str:

--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -164,7 +164,7 @@ def setup_platform(
                         entities.append(HubspaceOutlet(hs, friendlyName, outletIndex, debug, childId, model, deviceId, deviceClass))
                     except IndexError:
                         _LOGGER.debug('Error extracting outlet index')
-            elif deviceClass == 'landscape-transformer'
+            elif deviceClass == 'landscape-transformer':
                 for toggle in hs.getFunctions(childId, 'toggle'):
                     try:
                         _LOGGER.debug(f"Found toggle with id {toggle.get('id')} and instance {toggle.get('functionInstance')}")

--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -575,7 +575,10 @@ class HubspaceFan(LightEntity):
         """Return the state attributes."""
         attr = {}
         attr["model"]= self._model
-        attr["deviceId"] = self._deviceId + "_fan"
+        if self._name.endswith("_fan"):
+            attr["deviceId"] = self._deviceId + "_fan"
+        else:
+            attr["deviceId"] = self._deviceId
         attr["devbranch"] = False
         
         attr["debugInfo"] = self._debugInfo

--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -295,7 +295,7 @@ class HubspaceLight(LightEntity):
     @property
     def unique_id(self) -> str:
         """Return the display name of this light."""
-        return self._deviceId
+        return self._childId
 
     @property
     def color_mode(self) -> ColorMode:
@@ -445,7 +445,7 @@ class HubspaceOutlet(LightEntity):
     @property
     def unique_id(self) -> str:
         """Return the display name of this light."""
-        return self._deviceId + "_" + self._outletIndex 
+        return self._childId + "_" + self._outletIndex 
 
     @property
     def color_mode(self) -> ColorMode:
@@ -530,7 +530,7 @@ class HubspaceFan(LightEntity):
     @property
     def unique_id(self) -> str:
         """Return the display name of this light."""
-        return self._deviceId + "_fan" 
+        return self._childId
 
     @property
     def is_on(self) -> bool | None:
@@ -652,7 +652,7 @@ class HubspaceTransformer(LightEntity):
     @property
     def unique_id(self) -> str:
         """Return the display name of this light."""
-        return self._deviceId + "_" + self._outletIndex 
+        return self._childId + "_" + self._outletIndex 
 
     @property
     def color_mode(self) -> ColorMode:

--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -152,7 +152,6 @@ def setup_platform(
             _LOGGER.debug("deviceClass: " + deviceClass )
             _LOGGER.debug("friendlyName: " + friendlyName )
             
-            entities = _add_entity(entities, hs, model, deviceClass, friendlyName, debug)
             if deviceClass == 'fan':
                 entities.append(HubspaceFan(hs, friendlyName, debug, childId, model, deviceId, deviceClass))
             elif deviceClass == 'light':

--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -154,7 +154,7 @@ def setup_platform(
             
             if deviceClass == 'fan':
                 entities.append(HubspaceFan(hs, friendlyName, debug, childId, model, deviceId, deviceClass))
-            elif deviceClass == 'light':
+            elif deviceClass == 'light' or deviceClass == 'switch':
                 entities.append(HubspaceLight(hs, friendlyName, debug, childId, model, deviceId, deviceClass))
             elif deviceClass == 'power-outlet':
                 for toggle in hs.getFunctions(childId, 'toggle'):

--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -164,9 +164,7 @@ def setup_platform(
                         entities.append(HubspaceOutlet(hs, friendlyName, outletIndex, debug, childId, model, deviceId, deviceClass))
                     except IndexError:
                         _LOGGER.debug('Error extracting outlet index')
-            # TODO: Add support for Transformer device here: need a log to determine the deviceClass
-            '''
-            elif deviceClass == 'power-transformer???'
+            elif deviceClass == 'landscape-transformer'
                 for toggle in hs.getFunctions(childId, 'toggle'):
                     try:
                         _LOGGER.debug(f"Found toggle with id {toggle.get('id')} and instance {toggle.get('functionInstance')}")
@@ -174,7 +172,6 @@ def setup_platform(
                         entities.append(HubspaceTransformer(hs, friendlyName, outletIndex, debug, childId, model, deviceId, deviceClass))
                     except IndexError:
                         _LOGGER.debug('Error extracting outlet index')
-            '''
     
     if not entities:
         return


### PR DESCRIPTION
Begin support for #18 .

Add function to API to iterate over all device IDs to support automatic discovery.

Add function to API to get internal functions from a device ID.

If friendlynames or roomnames aren't specified, use automatic discovery. Currently working and tested for lights and fans. Needs testing for outlets. Needs additional data to finish transformer.

Use defined functions to determine outlet indexes and color temperatures supported.