### PR TITLE
Add support for the Hampton Bay 10W RGB Outdoor Stake Light

### DIFF
--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -431,7 +431,7 @@ class HubspaceLight(LightEntity):
             self._min_mireds = 154
         # https://www.homedepot.com/p/Hampton-Bay-10-Watt-Equivalent-Low-Voltage-Black-LED-Outdoor-Landscape-Spotlight-with-Smart-App-Control-3-Pack-Powered-by-Hubspace-L08557/318145795
         if (
-            self._model == "L008557"
+            self._model == "L08557"
         ):
             self._supported_color_modes.extend(
                 [ColorMode.RGB, ColorMode.COLOR_TEMP, ColorMode.WHITE]

--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -429,6 +429,15 @@ class HubspaceLight(LightEntity):
             )
             self._max_mireds = 370
             self._min_mireds = 154
+        # https://www.homedepot.com/p/Hampton-Bay-10-Watt-Equivalent-Low-Voltage-Black-LED-Outdoor-Landscape-Spotlight-with-Smart-App-Control-3-Pack-Powered-by-Hubspace-L08557/318145795
+        if (
+            self._model == "L008557"
+        ):
+            self._supported_color_modes.extend(
+                [ColorMode.RGB, ColorMode.COLOR_TEMP, ColorMode.WHITE]
+            )
+            self._max_mireds = 370
+            self._min_mireds = 154
         
         if (
             self._model == "ZandraFan"


### PR DESCRIPTION
Model number L08557. It appears to be very similar in functionality to existing lights with this color temperature spectrum.