### PR TITLE
Declare basic support for EcoSmart Smart RGWBIC strip lights

### DIFF
--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -359,6 +359,15 @@ class HubspaceLight(LightEntity):
             self._max_mireds = 454
             self._min_mireds = 154
             
+        # https://www.homedepot.com/p/EcoSmart-6-5-ft-Smart-RGWBIC-Dynamic-Color-Changing-Dimmable-Plug-In-LED-Strip-Light-Powered-by-Hubspace-AL-TP-RGBICTW-6/324731690
+        if (
+            self._model == "AL-TP-RGBICTW-6"
+        ):
+            self._usePowerFunctionInstance = "primary"
+            self._supported_color_modes.extend([ColorMode.RGB, ColorMode.COLOR_TEMP, ColorMode.WHITE])
+            self._max_mireds = 454
+            self._min_mireds = 154
+        
         # https://www.homedepot.com/p/Commercial-Electric-4-in-Smart-Hubspace-Color-Selectable-CCT-Integrated-LED-Recessed-Light-Trim-Works-with-Amazon-Alexa-and-Google-538551010/314199717
         # https://www.homedepot.com/p/Commercial-Electric-6-in-Smart-Hubspace-Ultra-Slim-New-Construction-and-Remodel-RGB-W-LED-Recessed-Kit-Works-with-Amazon-Alexa-and-Google-50292/313556988
         #  https://www.homedepot.com/p/EcoSmart-120-Watt-Equivalent-Smart-Hubspace-PAR38-Color-Changing-CEC-LED-Light-Bulb-with-Voice-Control-1-Bulb-11PR38120RGBWH1/318411934


### PR DESCRIPTION
Basic ON/OFF, color setting, and brightness control support for [EcoSmart 6.5 ft. Smart RGWBIC Dynamic Color Changing Dimmable Plug-In LED Strip Light](https://www.homedepot.com/p/EcoSmart-6-5-ft-Smart-RGWBIC-Dynamic-Color-Changing-Dimmable-Plug-In-LED-Strip-Light-Powered-by-Hubspace-AL-TP-RGBICTW-6/324731690) (AL-TP-RGBICTW-6). Treats strip light as one light and does not support segmentation, except through the integration's `send_command` service.