### PR TITLE
Add Vinwood Fan Support

### DIFF
--- a/custom_components/hubspace/hubspace.py
+++ b/custom_components/hubspace/hubspace.py
@@ -260,6 +260,8 @@ class HubSpace:
                     if model is not None and deviceClass is not None and defaultName is not None and defaultImage is not None:
                         if model == "" and defaultImage == "ceiling-fan-snyder-park-icon":
                             model = "DriskolFan"
+                        if model == "" and defaultImage == "ceiling-fan-vinings-icon":
+                            model = "VinwoodFan"
                         if deviceClass == "fan" and model == "TBD":
                             model = "ZandraFan"
                         if deviceClass == "fan" and model == "" and defaultImage == "ceiling-fan-slender-icon":
@@ -312,6 +314,8 @@ class HubSpace:
                     if model is not None and deviceClass is not None and defaultName is not None and defaultImage is not None:
                         if model == "" and defaultImage == "ceiling-fan-snyder-park-icon":
                             model = "DriskolFan"
+                        if model == "" and defaultImage == "ceiling-fan-vinings-icon":
+                            model = "VinwoodFan"
                         if deviceClass == "fan" and model == "TBD":
                             model = "ZandraFan"
                         if deviceClass == "fan" and model == "" and defaultImage == "ceiling-fan-slender-icon":

--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -95,7 +95,7 @@ def _add_entity(entities, hs, model, deviceClass, friendlyName, debug):
         entities.append(HubspaceFan(hs, friendlyName, debug))
         _LOGGER.debug("Creating Light")
         entities.append(HubspaceLight(hs, friendlyName, debug))
-    elif model == "DriskolFan" or model == "ZandraFan" or model == "TagerFan":
+    elif model == "DriskolFan" or model == "ZandraFan" or model == "TagerFan" or model == "VinwoodFan":
         _LOGGER.debug("Creating Fan")
         entities.append(HubspaceFan(hs, friendlyName, debug))
         _LOGGER.debug("Creating Light")
@@ -451,7 +451,16 @@ class HubspaceLight(LightEntity):
             )
             self._max_mireds = 370
             self._min_mireds = 154
-        
+        # https://www.homedepot.com/p/Home-Decorators-Collection-Vinwood-56-in-Indoor-White-Color-Changing-LED-Brushed-Nickel-Smart-Hubspace-Ceiling-Fan-with-Remote-Control-56002/320816365
+        if (
+            self._model == "VinwoodFan"
+        ):
+            self._supported_color_modes.extend(
+                [ColorMode.BRIGHTNESS]
+            )
+            self._usePowerFunctionInstance = "light-power"
+            self._max_mireds = 370
+            self._min_mireds = 154
         if (
             self._model == "ZandraFan"
         ):

--- a/sample_data/vinwoodfan.json
+++ b/sample_data/vinwoodfan.json
@@ -1,0 +1,5992 @@
+Hubspace Username: UUIDs, times, locations, names, MACs, and SSIDs have been redacted or randomized below.
+[
+    {
+        "children": [
+            "8156079a-e90a-4fe4-8ff9-fb8f7234f1b1",
+            "ab6ec9be-2a29-4e4e-8d18-d5ccb118e4e0",
+            "80236543-3928-417b-8842-aca93b22d17b",
+            "7040a41b-5950-4d7e-b01e-c5f0cc649102",
+            "a53d57d8-4ec2-455f-9e78-4338dcb82b00",
+            "8569cf0f-e7a3-432c-8be7-8497d5fb2de6",
+            "a66caf5f-3d97-4d92-8526-a3a169a3ef5c",
+            "4cad55ff-9dd3-4256-a8ea-7d0e2974c251",
+            "1b8c6a94-2f08-4838-8272-633b1234f010",
+            "0afe400e-a913-4f31-966c-0ef423057811",
+            "99898193-2135-47bb-816c-16789cd37e64",
+            "6634e952-823b-469b-a7f1-7ed0bb87b160",
+            "be921876-a3e2-4a04-9b3c-e705c366868d",
+            "b4c415a7-d2c2-4fe6-9178-540567424279",
+            "71abc0b6-059b-4eaf-9c91-be22d765f87f",
+            "7d1d7702-f19c-4271-935e-cc464ecdf60d",
+            "63277020-89ea-4218-9826-91ea58bc6b04",
+            "4ade6ca1-5fd9-4540-8106-fa9fa40332d8",
+            "51cff5ad-3c4e-4a89-9041-b49b896998b0",
+            "522f0a6f-7fe7-4f66-9582-bc3dfba4c20b",
+            "fea09103-ee7b-4492-bada-7a295a04eb27",
+            "7d4aa3fa-d4b0-41e9-bd38-a16e912d7a6b",
+            "2eeae13b-b7c7-4cda-9450-4b924f1efb51",
+            "c21bca60-c080-4c10-a137-a6006cbe7ed4"
+        ],
+        "createdTimestampMs": 1707016450670,
+        "friendlyName": "Friendly Name 16",
+        "id": "0a7b653d-7d60-4e15-a90e-4c3ca66bb6fd",
+        "locale": "en_US",
+        "typeId": "metadevice.home",
+        "updatedTimestampMs": 1707016450670,
+        "version": 1
+    },
+    {
+        "children": [],
+        "createdTimestampMs": 1707018091897,
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 17",
+        "id": "a53d57d8-4ec2-455f-9e78-4338dcb82b00",
+        "image": "wallpaper03.jpg",
+        "locale": "en_US",
+        "tag": "",
+        "typeId": "metadevice.room",
+        "updatedTimestampMs": 1707018325565,
+        "version": 1
+    },
+    {
+        "children": [],
+        "createdTimestampMs": 1708661039916,
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 5",
+        "id": "1b8c6a94-2f08-4838-8272-633b1234f010",
+        "image": "wallpaper11.jpg",
+        "locale": "en_US",
+        "tag": "",
+        "typeId": "metadevice.room",
+        "updatedTimestampMs": 1708661293092,
+        "version": 1
+    },
+    {
+        "children": [],
+        "createdTimestampMs": 1708146857671,
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 19",
+        "id": "0afe400e-a913-4f31-966c-0ef423057811",
+        "image": "wallpaper12.jpg",
+        "locale": "en_US",
+        "tag": "",
+        "typeId": "metadevice.room",
+        "updatedTimestampMs": 1708147596585,
+        "version": 1
+    },
+    {
+        "children": [],
+        "createdTimestampMs": 1708654734972,
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 14",
+        "id": "c21bca60-c080-4c10-a137-a6006cbe7ed4",
+        "image": "wallpaper01.jpg",
+        "locale": "en_US",
+        "tag": "",
+        "typeId": "metadevice.room",
+        "updatedTimestampMs": 1708655432742,
+        "version": 1
+    },
+    {
+        "children": [],
+        "createdTimestampMs": 1708324313362,
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 0",
+        "id": "fea09103-ee7b-4492-bada-7a295a04eb27",
+        "image": "wallpaper01.jpg",
+        "locale": "en_US",
+        "tag": "",
+        "typeId": "metadevice.room",
+        "updatedTimestampMs": 1708325136172,
+        "version": 1
+    },
+    {
+        "children": [
+            "63277020-89ea-4218-9826-91ea58bc6b04",
+            "8569cf0f-e7a3-432c-8be7-8497d5fb2de6",
+            "4cad55ff-9dd3-4256-a8ea-7d0e2974c251"
+        ],
+        "createdTimestampMs": 1708665209737,
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 8",
+        "id": "be921876-a3e2-4a04-9b3c-e705c366868d",
+        "image": "wallpaper01.jpg",
+        "locale": "en_US",
+        "tag": "",
+        "typeId": "metadevice.room",
+        "updatedTimestampMs": 1708665276194,
+        "version": 1
+    },
+    {
+        "children": [
+            "ab6ec9be-2a29-4e4e-8d18-d5ccb118e4e0",
+            "522f0a6f-7fe7-4f66-9582-bc3dfba4c20b"
+        ],
+        "createdTimestampMs": 1708322921974,
+        "description": {
+            "createdTimestampMs": 0,
+            "defaultImage": "ceiling-fan-vinings-icon",
+            "descriptions": [
+                {
+                    "createdTimestampMs": 0,
+                    "defaultImage": "ceiling-fan-vinings-icon",
+                    "descriptions": [],
+                    "device": {
+                        "defaultName": "Ceiling Light",
+                        "deviceClass": "light",
+                        "manufacturerName": "Friendly Name 16 Decorators Collection",
+                        "model": "",
+                        "type": "device"
+                    },
+                    "functions": [
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "brightness",
+                            "id": "acc24efd-6b5b-417e-acef-3055fac7cec1",
+                            "schedulable": true,
+                            "type": "numeric",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "59fdccc3-f7dd-4426-98bc-8234944d266d",
+                                            "key": "4",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0
+                                        }
+                                    ],
+                                    "id": "b755898b-5ac1-4f4d-84f6-d4f16d1f9747",
+                                    "name": "brightness",
+                                    "range": {
+                                        "max": 100,
+                                        "min": 1,
+                                        "step": 1
+                                    },
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "color-temperature",
+                            "id": "91d62b46-2296-4706-b147-8eef282dc3db",
+                            "schedulable": false,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "ae200aff-7013-45b1-867c-9fdb9b38e452",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "5000"
+                                        }
+                                    ],
+                                    "id": "a19754c6-cbde-4317-9a86-79224277309b",
+                                    "name": "5000K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "a1ed65f0-7d9b-4851-b615-54d8a70e590d",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "2700"
+                                        }
+                                    ],
+                                    "id": "8809d98b-68af-4d6c-ba5a-799bdb14141c",
+                                    "name": "2700K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "6d0cce0b-1e8d-43c4-bf02-d704a7dde524",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "3000"
+                                        }
+                                    ],
+                                    "id": "722731be-3737-4034-9bbb-9f4295b4a056",
+                                    "name": "3000K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "23f5c160-b7c9-4034-a2cb-7b111ad64eb6",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "4000"
+                                        }
+                                    ],
+                                    "id": "ac1a62e9-ab05-451a-817d-bdc8f128b244",
+                                    "name": "4000K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "1b089542-a293-4d69-b9bc-a9489028577a",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "3500"
+                                        }
+                                    ],
+                                    "id": "1a6c523e-c3d5-4110-80b6-e4da4d74b481",
+                                    "name": "3500K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "ed21d233-b38d-45ae-9b8b-02ca6c9e8be9",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "6500"
+                                        }
+                                    ],
+                                    "id": "43c078e4-ca62-48f7-83f4-5163cf51bc95",
+                                    "name": "6500K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "power",
+                            "functionInstance": "light-power",
+                            "id": "a5aaba54-a669-4a4d-8248-54afd0202116",
+                            "schedulable": true,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "f15cb5eb-52d2-4bf1-b58b-b03330c70650",
+                                            "key": "2",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "id": "5f06fac8-c990-44e0-a88c-84c77d8f8db6",
+                                    "name": "off",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "2e9d150e-398a-4f61-9aab-6acd5010dc18",
+                                            "key": "2",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "id": "3c2638d0-b4bf-4446-91db-9d448fa30025",
+                                    "name": "on",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "id": "2d555946-49a1-4c5a-92e7-aa17db309da5",
+                    "key": "light",
+                    "updatedTimestampMs": 0,
+                    "version": 1
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "defaultImage": "ceiling-fan-vinings-icon",
+                    "descriptions": [],
+                    "device": {
+                        "defaultName": "Ceiling Fan",
+                        "deviceClass": "fan",
+                        "manufacturerName": "Friendly Name 16 Decorators Collection",
+                        "model": "",
+                        "type": "device"
+                    },
+                    "functions": [
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "power",
+                            "functionInstance": "fan-power",
+                            "id": "a3856f01-4dcb-4782-aa14-e2ab71b49c2d",
+                            "schedulable": true,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "93fb1a6a-42f1-4b78-872b-197ee6028765",
+                                            "key": "3",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "id": "124a3fac-0713-4ccd-951c-1c8f04a19093",
+                                    "name": "off",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "d942af1f-16da-4bd9-b645-27b3f86f49b0",
+                                            "key": "3",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "id": "bfe3e6a1-0d34-48ba-996c-dd4ed1d718d0",
+                                    "name": "on",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "fan-speed",
+                            "functionInstance": "fan-speed",
+                            "id": "4d0615e9-779e-4eb6-a89a-da644a53d323",
+                            "schedulable": true,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "afa8a7fd-0247-4b41-a41a-ccdb8ca643b1",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "100"
+                                        }
+                                    ],
+                                    "id": "b8928f8c-35e9-4dc5-85dc-9e96b4bc8d5e",
+                                    "name": "fan-speed-5-100",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "059b47d1-08c6-42fe-87be-a654fa91a1e9",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "hints": [
+                                        "hidden"
+                                    ],
+                                    "id": "39aa1f38-f1cd-4389-8a10-37e91b6012a5",
+                                    "name": "fan-speed-5-000",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "d53c1cbe-b800-4ad4-90e2-20a74151ec2c",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "id": "0b61be46-e1a8-4031-9745-9350ce6a8fed",
+                                    "name": "fan-speed-5-020",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "77596065-33d3-4bd7-a850-3817b2fdc20c",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "80"
+                                        }
+                                    ],
+                                    "id": "15cdd8ab-c78f-4d30-93d2-3ff18faa0390",
+                                    "name": "fan-speed-5-080",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "13e38d04-00ba-4073-b95e-22473d5c1d43",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "60"
+                                        }
+                                    ],
+                                    "id": "8060e235-23c1-49b1-aa62-229983f3f9d2",
+                                    "name": "fan-speed-5-060",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "6ae9d25a-98fa-4d3c-854e-b345ab1ee8ad",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "40"
+                                        }
+                                    ],
+                                    "id": "2b7b4d0b-9b8f-44ad-bef9-1db3298c6e1b",
+                                    "name": "fan-speed-5-040",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "timer",
+                            "functionInstance": "fan-power",
+                            "id": "9cee70fb-0541-4bec-99dd-e231e3fa38a4",
+                            "schedulable": false,
+                            "type": "numeric",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "f9c9eb66-1e9f-4131-a982-795c4effc58c",
+                                            "key": "50",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0
+                                        }
+                                    ],
+                                    "id": "340adde0-70d5-48b5-8619-948a7b098a2a",
+                                    "name": "timer-1",
+                                    "range": {
+                                        "max": 1440,
+                                        "min": 0,
+                                        "step": 1
+                                    },
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "toggle",
+                            "functionInstance": "comfort-breeze",
+                            "id": "535a6c6f-13a5-4e7c-8aef-d26bfa080dd9",
+                            "schedulable": true,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "0f56d21e-bb9e-49a8-be85-343c7c4b7a00",
+                                            "key": "8",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "id": "e8ad9c61-2733-405f-8b27-e3032446654c",
+                                    "name": "disabled",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "af671fec-36d8-4bd6-9eca-8cb73258136b",
+                                            "key": "8",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "id": "13793ea4-8682-4901-994b-08d5bc46ea24",
+                                    "name": "enabled",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "fan-reverse",
+                            "functionInstance": "fan-reverse",
+                            "id": "ab596b48-3502-478d-88d9-47060a090828",
+                            "schedulable": false,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "f666b8cf-4a73-4ac3-9d5a-b90f87c9943e",
+                                            "key": "7",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "id": "d39fe935-3d6d-4af5-810b-71057923e7b0",
+                                    "name": "forward",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "5950e062-d9ef-4ec6-8423-22295ec0e1b0",
+                                            "key": "7",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "2"
+                                        }
+                                    ],
+                                    "hints": [
+                                        "voice-hidden"
+                                    ],
+                                    "id": "6ee8ea04-2263-4ee7-ae45-ad3b05c9cd85",
+                                    "name": "in-progress",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "5e463752-29f1-4ede-93f7-8ac73b00dfdf",
+                                            "key": "7",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "id": "8be96435-9fe7-415a-b965-6c2fe7f197ce",
+                                    "name": "reverse",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "id": "6da9eaf6-d22e-48f8-890c-cee12bf52732",
+                    "key": "fan",
+                    "updatedTimestampMs": 0,
+                    "version": 1
+                }
+            ],
+            "device": {
+                "defaultName": "Ceiling Fan",
+                "deviceClass": "ceiling-fan",
+                "manufacturerName": "Friendly Name 16 Decorators Collection",
+                "model": "",
+                "profileId": "d4ab40f7-cccb-4ad1-8f0d-87126897a00c",
+                "type": "device"
+            },
+            "functions": [
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "power",
+                    "functionInstance": "primary",
+                    "id": "7e87f3a9-8ac9-48b2-bcea-ba8edd8e5ca2",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "1cc87cdb-153d-437a-af40-5451a8285119",
+                                    "key": "1",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "d5caaab1-19a7-47c8-9244-9d4480380271",
+                            "name": "on",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "4c8268bc-3256-46e4-9354-aa47d623d4a1",
+                                    "key": "1",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "b5df2e5c-8c77-4d1d-b9ad-aaa0ac40fce4",
+                            "name": "off",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "error-flag",
+                    "functionInstance": "storage-error",
+                    "id": "c1c24bb0-b602-405f-80ff-264608cb0c58",
+                    "schedulable": false,
+                    "type": "boolean",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "847be297-c37c-4bfb-8d6f-4a709adc4fe4",
+                                    "key": "405",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0
+                                }
+                            ],
+                            "id": "faba93e6-05ef-4903-bf49-ce02d2fbc2bd",
+                            "name": "storage-error",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "error-flag",
+                    "functionInstance": "acz-error",
+                    "id": "96828943-0b9d-428e-9e99-5f103c261978",
+                    "schedulable": false,
+                    "type": "boolean",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "c8469c36-fced-4f3a-bb0d-2d1585f166f3",
+                                    "key": "406",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0
+                                }
+                            ],
+                            "id": "3da5e6b2-24ae-4cb9-9626-5c7d0c29e532",
+                            "name": "no-error",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                }
+            ],
+            "id": "60d8f4c8-a511-49ae-a152-e8f32b9e3622",
+            "updatedTimestampMs": 0,
+            "version": 1
+        },
+        "deviceId": "8b17809b941988cb",
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 0",
+        "id": "99898193-2135-47bb-816c-16789cd37e64",
+        "image": "",
+        "locale": "en_US",
+        "state": {
+            "metadeviceId": "99898193-2135-47bb-816c-16789cd37e64",
+            "values": [
+                {
+                    "functionClass": "power",
+                    "functionInstance": "primary",
+                    "lastUpdateTime": 1714004411987,
+                    "value": "on"
+                },
+                {
+                    "functionClass": "error-flag",
+                    "functionInstance": "storage-error",
+                    "lastUpdateTime": 1713728277424,
+                    "value": false
+                },
+                {
+                    "functionClass": "error-flag",
+                    "functionInstance": "acz-error",
+                    "lastUpdateTime": 1713728970324,
+                    "value": false
+                },
+                {
+                    "functionClass": "wifi-ssid",
+                    "lastUpdateTime": 1713730130428,
+                    "value": "SSID0"
+                },
+                {
+                    "functionClass": "wifi-rssi",
+                    "lastUpdateTime": 1713739658298,
+                    "value": -58
+                },
+                {
+                    "functionClass": "wifi-steady-state",
+                    "lastUpdateTime": 1713738860789,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-setup-state",
+                    "lastUpdateTime": 1713738877977,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "a6712594948a"
+                },
+                {
+                    "functionClass": "geo-coordinates",
+                    "functionInstance": "system-device-location",
+                    "lastUpdateTime": 1713730643523,
+                    "value": {
+                        "geo-coordinates": {
+                            "latitude": "0.4817174666068017",
+                            "longitude": "0.3616641479809084"
+                        }
+                    }
+                },
+                {
+                    "functionClass": "scheduler-flags",
+                    "lastUpdateTime": 1713729428984,
+                    "value": 1
+                },
+                {
+                    "functionClass": "available",
+                    "lastUpdateTime": 1713876388480,
+                    "value": true
+                },
+                {
+                    "functionClass": "visible",
+                    "lastUpdateTime": 1713876388480,
+                    "value": true
+                },
+                {
+                    "functionClass": "direct",
+                    "lastUpdateTime": 1713876388480,
+                    "value": true
+                },
+                {
+                    "functionClass": "ble-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "809b941988cb"
+                }
+            ]
+        },
+        "tag": "",
+        "typeId": "metadevice.device",
+        "updatedTimestampMs": 1708325452127,
+        "version": 1
+    },
+    {
+        "children": [],
+        "createdTimestampMs": 1708660533698,
+        "description": {
+            "createdTimestampMs": 0,
+            "defaultImage": "ceiling-fan-vinings-icon",
+            "descriptions": [],
+            "device": {
+                "defaultName": "Ceiling Fan",
+                "deviceClass": "fan",
+                "manufacturerName": "Friendly Name 16 Decorators Collection",
+                "model": "",
+                "type": "device"
+            },
+            "functions": [
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "power",
+                    "functionInstance": "fan-power",
+                    "id": "a3856f01-4dcb-4782-aa14-e2ab71b49c2d",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "93fb1a6a-42f1-4b78-872b-197ee6028765",
+                                    "key": "3",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "124a3fac-0713-4ccd-951c-1c8f04a19093",
+                            "name": "off",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "d942af1f-16da-4bd9-b645-27b3f86f49b0",
+                                    "key": "3",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "bfe3e6a1-0d34-48ba-996c-dd4ed1d718d0",
+                            "name": "on",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "fan-speed",
+                    "functionInstance": "fan-speed",
+                    "id": "4d0615e9-779e-4eb6-a89a-da644a53d323",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "afa8a7fd-0247-4b41-a41a-ccdb8ca643b1",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "100"
+                                }
+                            ],
+                            "id": "b8928f8c-35e9-4dc5-85dc-9e96b4bc8d5e",
+                            "name": "fan-speed-5-100",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "059b47d1-08c6-42fe-87be-a654fa91a1e9",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "hints": [
+                                "hidden"
+                            ],
+                            "id": "39aa1f38-f1cd-4389-8a10-37e91b6012a5",
+                            "name": "fan-speed-5-000",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "d53c1cbe-b800-4ad4-90e2-20a74151ec2c",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "20"
+                                }
+                            ],
+                            "id": "0b61be46-e1a8-4031-9745-9350ce6a8fed",
+                            "name": "fan-speed-5-020",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "77596065-33d3-4bd7-a850-3817b2fdc20c",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "80"
+                                }
+                            ],
+                            "id": "15cdd8ab-c78f-4d30-93d2-3ff18faa0390",
+                            "name": "fan-speed-5-080",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "13e38d04-00ba-4073-b95e-22473d5c1d43",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "60"
+                                }
+                            ],
+                            "id": "8060e235-23c1-49b1-aa62-229983f3f9d2",
+                            "name": "fan-speed-5-060",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "6ae9d25a-98fa-4d3c-854e-b345ab1ee8ad",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "40"
+                                }
+                            ],
+                            "id": "2b7b4d0b-9b8f-44ad-bef9-1db3298c6e1b",
+                            "name": "fan-speed-5-040",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "timer",
+                    "functionInstance": "fan-power",
+                    "id": "9cee70fb-0541-4bec-99dd-e231e3fa38a4",
+                    "schedulable": false,
+                    "type": "numeric",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "f9c9eb66-1e9f-4131-a982-795c4effc58c",
+                                    "key": "50",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0
+                                }
+                            ],
+                            "id": "340adde0-70d5-48b5-8619-948a7b098a2a",
+                            "name": "timer-1",
+                            "range": {
+                                "max": 1440,
+                                "min": 0,
+                                "step": 1
+                            },
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "toggle",
+                    "functionInstance": "comfort-breeze",
+                    "id": "535a6c6f-13a5-4e7c-8aef-d26bfa080dd9",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "0f56d21e-bb9e-49a8-be85-343c7c4b7a00",
+                                    "key": "8",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "e8ad9c61-2733-405f-8b27-e3032446654c",
+                            "name": "disabled",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "af671fec-36d8-4bd6-9eca-8cb73258136b",
+                                    "key": "8",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "13793ea4-8682-4901-994b-08d5bc46ea24",
+                            "name": "enabled",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "fan-reverse",
+                    "functionInstance": "fan-reverse",
+                    "id": "ab596b48-3502-478d-88d9-47060a090828",
+                    "schedulable": false,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "f666b8cf-4a73-4ac3-9d5a-b90f87c9943e",
+                                    "key": "7",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "d39fe935-3d6d-4af5-810b-71057923e7b0",
+                            "name": "forward",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "5950e062-d9ef-4ec6-8423-22295ec0e1b0",
+                                    "key": "7",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "2"
+                                }
+                            ],
+                            "hints": [
+                                "voice-hidden"
+                            ],
+                            "id": "6ee8ea04-2263-4ee7-ae45-ad3b05c9cd85",
+                            "name": "in-progress",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "5e463752-29f1-4ede-93f7-8ac73b00dfdf",
+                                    "key": "7",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "8be96435-9fe7-415a-b965-6c2fe7f197ce",
+                            "name": "reverse",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                }
+            ],
+            "id": "6da9eaf6-d22e-48f8-890c-cee12bf52732",
+            "key": "fan",
+            "updatedTimestampMs": 0,
+            "version": 1
+        },
+        "deviceId": "81005c3108184673",
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 5 Room Fan",
+        "id": "80236543-3928-417b-8842-aca93b22d17b",
+        "image": "",
+        "locale": "en_US",
+        "semanticDescriptionKey": "fan",
+        "state": {
+            "metadeviceId": "80236543-3928-417b-8842-aca93b22d17b",
+            "values": [
+                {
+                    "functionClass": "power",
+                    "functionInstance": "fan-power",
+                    "lastUpdateTime": 1713716578442,
+                    "value": "on"
+                },
+                {
+                    "functionClass": "fan-speed",
+                    "functionInstance": "fan-speed",
+                    "lastUpdateTime": 1713718082750,
+                    "value": "fan-speed-5-020"
+                },
+                {
+                    "functionClass": "timer",
+                    "functionInstance": "fan-power",
+                    "lastUpdateTime": 1713719547544,
+                    "value": 0
+                },
+                {
+                    "functionClass": "toggle",
+                    "functionInstance": "comfort-breeze",
+                    "lastUpdateTime": 1713718867243,
+                    "value": "disabled"
+                },
+                {
+                    "functionClass": "fan-reverse",
+                    "functionInstance": "fan-reverse",
+                    "lastUpdateTime": 1713720985129,
+                    "value": "forward"
+                },
+                {
+                    "functionClass": "wifi-ssid",
+                    "lastUpdateTime": 1713722466675,
+                    "value": "SSID0"
+                },
+                {
+                    "functionClass": "wifi-rssi",
+                    "lastUpdateTime": 1713733819460,
+                    "value": -45
+                },
+                {
+                    "functionClass": "wifi-steady-state",
+                    "lastUpdateTime": 1713732143105,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-setup-state",
+                    "lastUpdateTime": 1713732866261,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "5e2dc3520cfb"
+                },
+                {
+                    "functionClass": "geo-coordinates",
+                    "functionInstance": "system-device-location",
+                    "lastUpdateTime": 1713723366315,
+                    "value": {
+                        "geo-coordinates": {
+                            "latitude": "0.1368361169763389",
+                            "longitude": "0.555939958245533"
+                        }
+                    }
+                },
+                {
+                    "functionClass": "scheduler-flags",
+                    "lastUpdateTime": 1713721880926,
+                    "value": 0
+                },
+                {
+                    "functionClass": "available",
+                    "lastUpdateTime": 1713876698799,
+                    "value": true
+                },
+                {
+                    "functionClass": "visible",
+                    "lastUpdateTime": 1713876698799,
+                    "value": true
+                },
+                {
+                    "functionClass": "direct",
+                    "lastUpdateTime": 1713876698799,
+                    "value": true
+                },
+                {
+                    "functionClass": "ble-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "5c3108184673"
+                }
+            ]
+        },
+        "tag": "",
+        "typeId": "metadevice.device",
+        "updatedTimestampMs": 1710676417031,
+        "version": 1
+    },
+    {
+        "children": [],
+        "createdTimestampMs": 1708323713229,
+        "description": {
+            "createdTimestampMs": 0,
+            "defaultImage": "ceiling-fan-vinings-icon",
+            "descriptions": [],
+            "device": {
+                "defaultName": "Ceiling Fan",
+                "deviceClass": "fan",
+                "manufacturerName": "Friendly Name 16 Decorators Collection",
+                "model": "",
+                "type": "device"
+            },
+            "functions": [
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "power",
+                    "functionInstance": "fan-power",
+                    "id": "a3856f01-4dcb-4782-aa14-e2ab71b49c2d",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "93fb1a6a-42f1-4b78-872b-197ee6028765",
+                                    "key": "3",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "124a3fac-0713-4ccd-951c-1c8f04a19093",
+                            "name": "off",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "d942af1f-16da-4bd9-b645-27b3f86f49b0",
+                                    "key": "3",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "bfe3e6a1-0d34-48ba-996c-dd4ed1d718d0",
+                            "name": "on",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "fan-speed",
+                    "functionInstance": "fan-speed",
+                    "id": "4d0615e9-779e-4eb6-a89a-da644a53d323",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "afa8a7fd-0247-4b41-a41a-ccdb8ca643b1",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "100"
+                                }
+                            ],
+                            "id": "b8928f8c-35e9-4dc5-85dc-9e96b4bc8d5e",
+                            "name": "fan-speed-5-100",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "059b47d1-08c6-42fe-87be-a654fa91a1e9",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "hints": [
+                                "hidden"
+                            ],
+                            "id": "39aa1f38-f1cd-4389-8a10-37e91b6012a5",
+                            "name": "fan-speed-5-000",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "d53c1cbe-b800-4ad4-90e2-20a74151ec2c",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "20"
+                                }
+                            ],
+                            "id": "0b61be46-e1a8-4031-9745-9350ce6a8fed",
+                            "name": "fan-speed-5-020",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "77596065-33d3-4bd7-a850-3817b2fdc20c",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "80"
+                                }
+                            ],
+                            "id": "15cdd8ab-c78f-4d30-93d2-3ff18faa0390",
+                            "name": "fan-speed-5-080",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "13e38d04-00ba-4073-b95e-22473d5c1d43",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "60"
+                                }
+                            ],
+                            "id": "8060e235-23c1-49b1-aa62-229983f3f9d2",
+                            "name": "fan-speed-5-060",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "6ae9d25a-98fa-4d3c-854e-b345ab1ee8ad",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "40"
+                                }
+                            ],
+                            "id": "2b7b4d0b-9b8f-44ad-bef9-1db3298c6e1b",
+                            "name": "fan-speed-5-040",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "timer",
+                    "functionInstance": "fan-power",
+                    "id": "9cee70fb-0541-4bec-99dd-e231e3fa38a4",
+                    "schedulable": false,
+                    "type": "numeric",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "f9c9eb66-1e9f-4131-a982-795c4effc58c",
+                                    "key": "50",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0
+                                }
+                            ],
+                            "id": "340adde0-70d5-48b5-8619-948a7b098a2a",
+                            "name": "timer-1",
+                            "range": {
+                                "max": 1440,
+                                "min": 0,
+                                "step": 1
+                            },
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "toggle",
+                    "functionInstance": "comfort-breeze",
+                    "id": "535a6c6f-13a5-4e7c-8aef-d26bfa080dd9",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "0f56d21e-bb9e-49a8-be85-343c7c4b7a00",
+                                    "key": "8",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "e8ad9c61-2733-405f-8b27-e3032446654c",
+                            "name": "disabled",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "af671fec-36d8-4bd6-9eca-8cb73258136b",
+                                    "key": "8",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "13793ea4-8682-4901-994b-08d5bc46ea24",
+                            "name": "enabled",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "fan-reverse",
+                    "functionInstance": "fan-reverse",
+                    "id": "ab596b48-3502-478d-88d9-47060a090828",
+                    "schedulable": false,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "f666b8cf-4a73-4ac3-9d5a-b90f87c9943e",
+                                    "key": "7",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "d39fe935-3d6d-4af5-810b-71057923e7b0",
+                            "name": "forward",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "5950e062-d9ef-4ec6-8423-22295ec0e1b0",
+                                    "key": "7",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "2"
+                                }
+                            ],
+                            "hints": [
+                                "voice-hidden"
+                            ],
+                            "id": "6ee8ea04-2263-4ee7-ae45-ad3b05c9cd85",
+                            "name": "in-progress",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "5e463752-29f1-4ede-93f7-8ac73b00dfdf",
+                                    "key": "7",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "8be96435-9fe7-415a-b965-6c2fe7f197ce",
+                            "name": "reverse",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                }
+            ],
+            "id": "6da9eaf6-d22e-48f8-890c-cee12bf52732",
+            "key": "fan",
+            "updatedTimestampMs": 0,
+            "version": 1
+        },
+        "deviceId": "8b17809b941988cb",
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 0 Fan",
+        "id": "522f0a6f-7fe7-4f66-9582-bc3dfba4c20b",
+        "image": "",
+        "locale": "en_US",
+        "semanticDescriptionKey": "fan",
+        "state": {
+            "metadeviceId": "522f0a6f-7fe7-4f66-9582-bc3dfba4c20b",
+            "values": [
+                {
+                    "functionClass": "power",
+                    "functionInstance": "fan-power",
+                    "lastUpdateTime": 1714007690851,
+                    "value": "on"
+                },
+                {
+                    "functionClass": "fan-speed",
+                    "functionInstance": "fan-speed",
+                    "lastUpdateTime": 1713828000516,
+                    "value": "fan-speed-5-060"
+                },
+                {
+                    "functionClass": "timer",
+                    "functionInstance": "fan-power",
+                    "lastUpdateTime": 1713728171462,
+                    "value": 0
+                },
+                {
+                    "functionClass": "toggle",
+                    "functionInstance": "comfort-breeze",
+                    "lastUpdateTime": 1713727755837,
+                    "value": "disabled"
+                },
+                {
+                    "functionClass": "fan-reverse",
+                    "functionInstance": "fan-reverse",
+                    "lastUpdateTime": 1713727490820,
+                    "value": "forward"
+                },
+                {
+                    "functionClass": "wifi-ssid",
+                    "lastUpdateTime": 1713730130428,
+                    "value": "SSID0"
+                },
+                {
+                    "functionClass": "wifi-rssi",
+                    "lastUpdateTime": 1713739658298,
+                    "value": -58
+                },
+                {
+                    "functionClass": "wifi-steady-state",
+                    "lastUpdateTime": 1713738860789,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-setup-state",
+                    "lastUpdateTime": 1713738877977,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "a6712594948a"
+                },
+                {
+                    "functionClass": "geo-coordinates",
+                    "functionInstance": "system-device-location",
+                    "lastUpdateTime": 1713730643523,
+                    "value": {
+                        "geo-coordinates": {
+                            "latitude": "0.4817174666068017",
+                            "longitude": "0.3616641479809084"
+                        }
+                    }
+                },
+                {
+                    "functionClass": "scheduler-flags",
+                    "lastUpdateTime": 1713729428984,
+                    "value": 1
+                },
+                {
+                    "functionClass": "available",
+                    "lastUpdateTime": 1713876388480,
+                    "value": true
+                },
+                {
+                    "functionClass": "visible",
+                    "lastUpdateTime": 1713876388480,
+                    "value": true
+                },
+                {
+                    "functionClass": "direct",
+                    "lastUpdateTime": 1713876388480,
+                    "value": true
+                },
+                {
+                    "functionClass": "ble-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "809b941988cb"
+                }
+            ]
+        },
+        "tag": "",
+        "typeId": "metadevice.device",
+        "updatedTimestampMs": 1710675427334,
+        "version": 1
+    },
+    {
+        "children": [],
+        "createdTimestampMs": 1708323589790,
+        "description": {
+            "createdTimestampMs": 0,
+            "defaultImage": "ceiling-fan-vinings-icon",
+            "descriptions": [],
+            "device": {
+                "defaultName": "Ceiling Light",
+                "deviceClass": "light",
+                "manufacturerName": "Friendly Name 16 Decorators Collection",
+                "model": "",
+                "type": "device"
+            },
+            "functions": [
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "brightness",
+                    "id": "acc24efd-6b5b-417e-acef-3055fac7cec1",
+                    "schedulable": true,
+                    "type": "numeric",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "59fdccc3-f7dd-4426-98bc-8234944d266d",
+                                    "key": "4",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0
+                                }
+                            ],
+                            "id": "b755898b-5ac1-4f4d-84f6-d4f16d1f9747",
+                            "name": "brightness",
+                            "range": {
+                                "max": 100,
+                                "min": 1,
+                                "step": 1
+                            },
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "color-temperature",
+                    "id": "91d62b46-2296-4706-b147-8eef282dc3db",
+                    "schedulable": false,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "ae200aff-7013-45b1-867c-9fdb9b38e452",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "5000"
+                                }
+                            ],
+                            "id": "a19754c6-cbde-4317-9a86-79224277309b",
+                            "name": "5000K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "a1ed65f0-7d9b-4851-b615-54d8a70e590d",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "2700"
+                                }
+                            ],
+                            "id": "8809d98b-68af-4d6c-ba5a-799bdb14141c",
+                            "name": "2700K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "6d0cce0b-1e8d-43c4-bf02-d704a7dde524",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "3000"
+                                }
+                            ],
+                            "id": "722731be-3737-4034-9bbb-9f4295b4a056",
+                            "name": "3000K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "23f5c160-b7c9-4034-a2cb-7b111ad64eb6",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "4000"
+                                }
+                            ],
+                            "id": "ac1a62e9-ab05-451a-817d-bdc8f128b244",
+                            "name": "4000K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "1b089542-a293-4d69-b9bc-a9489028577a",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "3500"
+                                }
+                            ],
+                            "id": "1a6c523e-c3d5-4110-80b6-e4da4d74b481",
+                            "name": "3500K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "ed21d233-b38d-45ae-9b8b-02ca6c9e8be9",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "6500"
+                                }
+                            ],
+                            "id": "43c078e4-ca62-48f7-83f4-5163cf51bc95",
+                            "name": "6500K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "power",
+                    "functionInstance": "light-power",
+                    "id": "a5aaba54-a669-4a4d-8248-54afd0202116",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "f15cb5eb-52d2-4bf1-b58b-b03330c70650",
+                                    "key": "2",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "5f06fac8-c990-44e0-a88c-84c77d8f8db6",
+                            "name": "off",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "2e9d150e-398a-4f61-9aab-6acd5010dc18",
+                                    "key": "2",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "3c2638d0-b4bf-4446-91db-9d448fa30025",
+                            "name": "on",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                }
+            ],
+            "id": "2d555946-49a1-4c5a-92e7-aa17db309da5",
+            "key": "light",
+            "updatedTimestampMs": 0,
+            "version": 1
+        },
+        "deviceId": "8b17809b941988cb",
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 0 Light",
+        "id": "ab6ec9be-2a29-4e4e-8d18-d5ccb118e4e0",
+        "image": "",
+        "locale": "en_US",
+        "semanticDescriptionKey": "light",
+        "state": {
+            "metadeviceId": "ab6ec9be-2a29-4e4e-8d18-d5ccb118e4e0",
+            "values": [
+                {
+                    "functionClass": "brightness",
+                    "lastUpdateTime": 1713726666165,
+                    "value": 50
+                },
+                {
+                    "functionClass": "color-temperature",
+                    "lastUpdateTime": 1713727203210,
+                    "value": "2700K"
+                },
+                {
+                    "functionClass": "power",
+                    "functionInstance": "light-power",
+                    "lastUpdateTime": 1714009034721,
+                    "value": "off"
+                },
+                {
+                    "functionClass": "wifi-ssid",
+                    "lastUpdateTime": 1713730130428,
+                    "value": "SSID0"
+                },
+                {
+                    "functionClass": "wifi-rssi",
+                    "lastUpdateTime": 1713739658298,
+                    "value": -58
+                },
+                {
+                    "functionClass": "wifi-steady-state",
+                    "lastUpdateTime": 1713738860789,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-setup-state",
+                    "lastUpdateTime": 1713738877977,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "a6712594948a"
+                },
+                {
+                    "functionClass": "geo-coordinates",
+                    "functionInstance": "system-device-location",
+                    "lastUpdateTime": 1713730643523,
+                    "value": {
+                        "geo-coordinates": {
+                            "latitude": "0.4817174666068017",
+                            "longitude": "0.3616641479809084"
+                        }
+                    }
+                },
+                {
+                    "functionClass": "scheduler-flags",
+                    "lastUpdateTime": 1713729428984,
+                    "value": 1
+                },
+                {
+                    "functionClass": "available",
+                    "lastUpdateTime": 1713876388480,
+                    "value": true
+                },
+                {
+                    "functionClass": "visible",
+                    "lastUpdateTime": 1713876388480,
+                    "value": true
+                },
+                {
+                    "functionClass": "direct",
+                    "lastUpdateTime": 1713876388480,
+                    "value": true
+                },
+                {
+                    "functionClass": "ble-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "809b941988cb"
+                }
+            ]
+        },
+        "tag": "",
+        "typeId": "metadevice.device",
+        "updatedTimestampMs": 1710675162698,
+        "version": 1
+    },
+    {
+        "children": [],
+        "createdTimestampMs": 1708654282095,
+        "description": {
+            "createdTimestampMs": 0,
+            "defaultImage": "ceiling-fan-vinings-icon",
+            "descriptions": [],
+            "device": {
+                "defaultName": "Ceiling Fan",
+                "deviceClass": "fan",
+                "manufacturerName": "Friendly Name 16 Decorators Collection",
+                "model": "",
+                "type": "device"
+            },
+            "functions": [
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "power",
+                    "functionInstance": "fan-power",
+                    "id": "a3856f01-4dcb-4782-aa14-e2ab71b49c2d",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "93fb1a6a-42f1-4b78-872b-197ee6028765",
+                                    "key": "3",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "124a3fac-0713-4ccd-951c-1c8f04a19093",
+                            "name": "off",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "d942af1f-16da-4bd9-b645-27b3f86f49b0",
+                                    "key": "3",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "bfe3e6a1-0d34-48ba-996c-dd4ed1d718d0",
+                            "name": "on",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "fan-speed",
+                    "functionInstance": "fan-speed",
+                    "id": "4d0615e9-779e-4eb6-a89a-da644a53d323",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "afa8a7fd-0247-4b41-a41a-ccdb8ca643b1",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "100"
+                                }
+                            ],
+                            "id": "b8928f8c-35e9-4dc5-85dc-9e96b4bc8d5e",
+                            "name": "fan-speed-5-100",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "059b47d1-08c6-42fe-87be-a654fa91a1e9",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "hints": [
+                                "hidden"
+                            ],
+                            "id": "39aa1f38-f1cd-4389-8a10-37e91b6012a5",
+                            "name": "fan-speed-5-000",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "d53c1cbe-b800-4ad4-90e2-20a74151ec2c",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "20"
+                                }
+                            ],
+                            "id": "0b61be46-e1a8-4031-9745-9350ce6a8fed",
+                            "name": "fan-speed-5-020",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "77596065-33d3-4bd7-a850-3817b2fdc20c",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "80"
+                                }
+                            ],
+                            "id": "15cdd8ab-c78f-4d30-93d2-3ff18faa0390",
+                            "name": "fan-speed-5-080",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "13e38d04-00ba-4073-b95e-22473d5c1d43",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "60"
+                                }
+                            ],
+                            "id": "8060e235-23c1-49b1-aa62-229983f3f9d2",
+                            "name": "fan-speed-5-060",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "6ae9d25a-98fa-4d3c-854e-b345ab1ee8ad",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "40"
+                                }
+                            ],
+                            "id": "2b7b4d0b-9b8f-44ad-bef9-1db3298c6e1b",
+                            "name": "fan-speed-5-040",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "timer",
+                    "functionInstance": "fan-power",
+                    "id": "9cee70fb-0541-4bec-99dd-e231e3fa38a4",
+                    "schedulable": false,
+                    "type": "numeric",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "f9c9eb66-1e9f-4131-a982-795c4effc58c",
+                                    "key": "50",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0
+                                }
+                            ],
+                            "id": "340adde0-70d5-48b5-8619-948a7b098a2a",
+                            "name": "timer-1",
+                            "range": {
+                                "max": 1440,
+                                "min": 0,
+                                "step": 1
+                            },
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "toggle",
+                    "functionInstance": "comfort-breeze",
+                    "id": "535a6c6f-13a5-4e7c-8aef-d26bfa080dd9",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "0f56d21e-bb9e-49a8-be85-343c7c4b7a00",
+                                    "key": "8",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "e8ad9c61-2733-405f-8b27-e3032446654c",
+                            "name": "disabled",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "af671fec-36d8-4bd6-9eca-8cb73258136b",
+                                    "key": "8",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "13793ea4-8682-4901-994b-08d5bc46ea24",
+                            "name": "enabled",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "fan-reverse",
+                    "functionInstance": "fan-reverse",
+                    "id": "ab596b48-3502-478d-88d9-47060a090828",
+                    "schedulable": false,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "f666b8cf-4a73-4ac3-9d5a-b90f87c9943e",
+                                    "key": "7",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "d39fe935-3d6d-4af5-810b-71057923e7b0",
+                            "name": "forward",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "5950e062-d9ef-4ec6-8423-22295ec0e1b0",
+                                    "key": "7",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "2"
+                                }
+                            ],
+                            "hints": [
+                                "voice-hidden"
+                            ],
+                            "id": "6ee8ea04-2263-4ee7-ae45-ad3b05c9cd85",
+                            "name": "in-progress",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "5e463752-29f1-4ede-93f7-8ac73b00dfdf",
+                                    "key": "7",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "8be96435-9fe7-415a-b965-6c2fe7f197ce",
+                            "name": "reverse",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                }
+            ],
+            "id": "6da9eaf6-d22e-48f8-890c-cee12bf52732",
+            "key": "fan",
+            "updatedTimestampMs": 0,
+            "version": 1
+        },
+        "deviceId": "8f8eea7c73f8d4ff",
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 6",
+        "id": "a66caf5f-3d97-4d92-8526-a3a169a3ef5c",
+        "image": "",
+        "locale": "en_US",
+        "semanticDescriptionKey": "fan",
+        "state": {
+            "metadeviceId": "a66caf5f-3d97-4d92-8526-a3a169a3ef5c",
+            "values": [
+                {
+                    "functionClass": "power",
+                    "functionInstance": "fan-power",
+                    "lastUpdateTime": 1713707415237,
+                    "value": "on"
+                },
+                {
+                    "functionClass": "fan-speed",
+                    "functionInstance": "fan-speed",
+                    "lastUpdateTime": 1713712713073,
+                    "value": "fan-speed-5-040"
+                },
+                {
+                    "functionClass": "timer",
+                    "functionInstance": "fan-power",
+                    "lastUpdateTime": 1713709833026,
+                    "value": 0
+                },
+                {
+                    "functionClass": "toggle",
+                    "functionInstance": "comfort-breeze",
+                    "lastUpdateTime": 1713709367557,
+                    "value": "disabled"
+                },
+                {
+                    "functionClass": "fan-reverse",
+                    "functionInstance": "fan-reverse",
+                    "lastUpdateTime": 1713708610600,
+                    "value": "forward"
+                },
+                {
+                    "functionClass": "wifi-ssid",
+                    "lastUpdateTime": 1713711789519,
+                    "value": "SSID0"
+                },
+                {
+                    "functionClass": "wifi-rssi",
+                    "lastUpdateTime": 1713736061077,
+                    "value": -25
+                },
+                {
+                    "functionClass": "wifi-steady-state",
+                    "lastUpdateTime": 1713735267305,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-setup-state",
+                    "lastUpdateTime": 1713735415129,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "692983d53aa6"
+                },
+                {
+                    "functionClass": "geo-coordinates",
+                    "functionInstance": "system-device-location",
+                    "lastUpdateTime": 1713712144689
+                },
+                {
+                    "functionClass": "scheduler-flags",
+                    "lastUpdateTime": 1713710932221,
+                    "value": 0
+                },
+                {
+                    "functionClass": "available",
+                    "lastUpdateTime": 1713740070580,
+                    "value": true
+                },
+                {
+                    "functionClass": "visible",
+                    "lastUpdateTime": 1713740070580,
+                    "value": true
+                },
+                {
+                    "functionClass": "direct",
+                    "lastUpdateTime": 1713740070580,
+                    "value": true
+                },
+                {
+                    "functionClass": "ble-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "ea7c73f8d4ff"
+                }
+            ]
+        },
+        "tag": "",
+        "typeId": "metadevice.device",
+        "updatedTimestampMs": 1710680000800,
+        "version": 1
+    },
+    {
+        "children": [],
+        "createdTimestampMs": 1708653762330,
+        "description": {
+            "createdTimestampMs": 0,
+            "defaultImage": "ceiling-fan-vinings-icon",
+            "descriptions": [],
+            "device": {
+                "defaultName": "Ceiling Light",
+                "deviceClass": "light",
+                "manufacturerName": "Friendly Name 16 Decorators Collection",
+                "model": "",
+                "type": "device"
+            },
+            "functions": [
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "brightness",
+                    "id": "acc24efd-6b5b-417e-acef-3055fac7cec1",
+                    "schedulable": true,
+                    "type": "numeric",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "59fdccc3-f7dd-4426-98bc-8234944d266d",
+                                    "key": "4",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0
+                                }
+                            ],
+                            "id": "b755898b-5ac1-4f4d-84f6-d4f16d1f9747",
+                            "name": "brightness",
+                            "range": {
+                                "max": 100,
+                                "min": 1,
+                                "step": 1
+                            },
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "color-temperature",
+                    "id": "91d62b46-2296-4706-b147-8eef282dc3db",
+                    "schedulable": false,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "ae200aff-7013-45b1-867c-9fdb9b38e452",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "5000"
+                                }
+                            ],
+                            "id": "a19754c6-cbde-4317-9a86-79224277309b",
+                            "name": "5000K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "a1ed65f0-7d9b-4851-b615-54d8a70e590d",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "2700"
+                                }
+                            ],
+                            "id": "8809d98b-68af-4d6c-ba5a-799bdb14141c",
+                            "name": "2700K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "6d0cce0b-1e8d-43c4-bf02-d704a7dde524",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "3000"
+                                }
+                            ],
+                            "id": "722731be-3737-4034-9bbb-9f4295b4a056",
+                            "name": "3000K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "23f5c160-b7c9-4034-a2cb-7b111ad64eb6",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "4000"
+                                }
+                            ],
+                            "id": "ac1a62e9-ab05-451a-817d-bdc8f128b244",
+                            "name": "4000K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "1b089542-a293-4d69-b9bc-a9489028577a",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "3500"
+                                }
+                            ],
+                            "id": "1a6c523e-c3d5-4110-80b6-e4da4d74b481",
+                            "name": "3500K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "ed21d233-b38d-45ae-9b8b-02ca6c9e8be9",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "6500"
+                                }
+                            ],
+                            "id": "43c078e4-ca62-48f7-83f4-5163cf51bc95",
+                            "name": "6500K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "power",
+                    "functionInstance": "light-power",
+                    "id": "a5aaba54-a669-4a4d-8248-54afd0202116",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "f15cb5eb-52d2-4bf1-b58b-b03330c70650",
+                                    "key": "2",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "5f06fac8-c990-44e0-a88c-84c77d8f8db6",
+                            "name": "off",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "2e9d150e-398a-4f61-9aab-6acd5010dc18",
+                                    "key": "2",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "3c2638d0-b4bf-4446-91db-9d448fa30025",
+                            "name": "on",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                }
+            ],
+            "id": "2d555946-49a1-4c5a-92e7-aa17db309da5",
+            "key": "light",
+            "updatedTimestampMs": 0,
+            "version": 1
+        },
+        "deviceId": "8f8eea7c73f8d4ff",
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 2",
+        "id": "4ade6ca1-5fd9-4540-8106-fa9fa40332d8",
+        "image": "",
+        "locale": "en_US",
+        "semanticDescriptionKey": "light",
+        "state": {
+            "metadeviceId": "4ade6ca1-5fd9-4540-8106-fa9fa40332d8",
+            "values": [
+                {
+                    "functionClass": "brightness",
+                    "lastUpdateTime": 1713713078457,
+                    "value": 100
+                },
+                {
+                    "functionClass": "color-temperature",
+                    "lastUpdateTime": 1713708400741,
+                    "value": "3000K"
+                },
+                {
+                    "functionClass": "power",
+                    "functionInstance": "light-power",
+                    "lastUpdateTime": 1713714004938,
+                    "value": "off"
+                },
+                {
+                    "functionClass": "wifi-ssid",
+                    "lastUpdateTime": 1713711789519,
+                    "value": "SSID0"
+                },
+                {
+                    "functionClass": "wifi-rssi",
+                    "lastUpdateTime": 1713736061077,
+                    "value": -25
+                },
+                {
+                    "functionClass": "wifi-steady-state",
+                    "lastUpdateTime": 1713735267305,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-setup-state",
+                    "lastUpdateTime": 1713735415129,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "692983d53aa6"
+                },
+                {
+                    "functionClass": "geo-coordinates",
+                    "functionInstance": "system-device-location",
+                    "lastUpdateTime": 1713712144689
+                },
+                {
+                    "functionClass": "scheduler-flags",
+                    "lastUpdateTime": 1713710932221,
+                    "value": 0
+                },
+                {
+                    "functionClass": "available",
+                    "lastUpdateTime": 1713740070580,
+                    "value": true
+                },
+                {
+                    "functionClass": "visible",
+                    "lastUpdateTime": 1713740070580,
+                    "value": true
+                },
+                {
+                    "functionClass": "direct",
+                    "lastUpdateTime": 1713740070580,
+                    "value": true
+                },
+                {
+                    "functionClass": "ble-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "ea7c73f8d4ff"
+                }
+            ]
+        },
+        "tag": "",
+        "typeId": "metadevice.device",
+        "updatedTimestampMs": 1710679211875,
+        "version": 1
+    },
+    {
+        "children": [
+            "63277020-89ea-4218-9826-91ea58bc6b04",
+            "8569cf0f-e7a3-432c-8be7-8497d5fb2de6"
+        ],
+        "createdTimestampMs": 1708664735231,
+        "description": {
+            "createdTimestampMs": 0,
+            "defaultImage": "ceiling-fan-vinings-icon",
+            "descriptions": [
+                {
+                    "createdTimestampMs": 0,
+                    "defaultImage": "ceiling-fan-vinings-icon",
+                    "descriptions": [],
+                    "device": {
+                        "defaultName": "Ceiling Light",
+                        "deviceClass": "light",
+                        "manufacturerName": "Friendly Name 16 Decorators Collection",
+                        "model": "",
+                        "type": "device"
+                    },
+                    "functions": [
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "brightness",
+                            "id": "acc24efd-6b5b-417e-acef-3055fac7cec1",
+                            "schedulable": true,
+                            "type": "numeric",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "59fdccc3-f7dd-4426-98bc-8234944d266d",
+                                            "key": "4",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0
+                                        }
+                                    ],
+                                    "id": "b755898b-5ac1-4f4d-84f6-d4f16d1f9747",
+                                    "name": "brightness",
+                                    "range": {
+                                        "max": 100,
+                                        "min": 1,
+                                        "step": 1
+                                    },
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "color-temperature",
+                            "id": "91d62b46-2296-4706-b147-8eef282dc3db",
+                            "schedulable": false,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "ae200aff-7013-45b1-867c-9fdb9b38e452",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "5000"
+                                        }
+                                    ],
+                                    "id": "a19754c6-cbde-4317-9a86-79224277309b",
+                                    "name": "5000K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "a1ed65f0-7d9b-4851-b615-54d8a70e590d",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "2700"
+                                        }
+                                    ],
+                                    "id": "8809d98b-68af-4d6c-ba5a-799bdb14141c",
+                                    "name": "2700K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "6d0cce0b-1e8d-43c4-bf02-d704a7dde524",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "3000"
+                                        }
+                                    ],
+                                    "id": "722731be-3737-4034-9bbb-9f4295b4a056",
+                                    "name": "3000K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "23f5c160-b7c9-4034-a2cb-7b111ad64eb6",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "4000"
+                                        }
+                                    ],
+                                    "id": "ac1a62e9-ab05-451a-817d-bdc8f128b244",
+                                    "name": "4000K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "1b089542-a293-4d69-b9bc-a9489028577a",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "3500"
+                                        }
+                                    ],
+                                    "id": "1a6c523e-c3d5-4110-80b6-e4da4d74b481",
+                                    "name": "3500K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "ed21d233-b38d-45ae-9b8b-02ca6c9e8be9",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "6500"
+                                        }
+                                    ],
+                                    "id": "43c078e4-ca62-48f7-83f4-5163cf51bc95",
+                                    "name": "6500K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "power",
+                            "functionInstance": "light-power",
+                            "id": "a5aaba54-a669-4a4d-8248-54afd0202116",
+                            "schedulable": true,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "f15cb5eb-52d2-4bf1-b58b-b03330c70650",
+                                            "key": "2",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "id": "5f06fac8-c990-44e0-a88c-84c77d8f8db6",
+                                    "name": "off",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "2e9d150e-398a-4f61-9aab-6acd5010dc18",
+                                            "key": "2",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "id": "3c2638d0-b4bf-4446-91db-9d448fa30025",
+                                    "name": "on",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "id": "2d555946-49a1-4c5a-92e7-aa17db309da5",
+                    "key": "light",
+                    "updatedTimestampMs": 0,
+                    "version": 1
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "defaultImage": "ceiling-fan-vinings-icon",
+                    "descriptions": [],
+                    "device": {
+                        "defaultName": "Ceiling Fan",
+                        "deviceClass": "fan",
+                        "manufacturerName": "Friendly Name 16 Decorators Collection",
+                        "model": "",
+                        "type": "device"
+                    },
+                    "functions": [
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "power",
+                            "functionInstance": "fan-power",
+                            "id": "a3856f01-4dcb-4782-aa14-e2ab71b49c2d",
+                            "schedulable": true,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "93fb1a6a-42f1-4b78-872b-197ee6028765",
+                                            "key": "3",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "id": "124a3fac-0713-4ccd-951c-1c8f04a19093",
+                                    "name": "off",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "d942af1f-16da-4bd9-b645-27b3f86f49b0",
+                                            "key": "3",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "id": "bfe3e6a1-0d34-48ba-996c-dd4ed1d718d0",
+                                    "name": "on",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "fan-speed",
+                            "functionInstance": "fan-speed",
+                            "id": "4d0615e9-779e-4eb6-a89a-da644a53d323",
+                            "schedulable": true,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "afa8a7fd-0247-4b41-a41a-ccdb8ca643b1",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "100"
+                                        }
+                                    ],
+                                    "id": "b8928f8c-35e9-4dc5-85dc-9e96b4bc8d5e",
+                                    "name": "fan-speed-5-100",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "059b47d1-08c6-42fe-87be-a654fa91a1e9",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "hints": [
+                                        "hidden"
+                                    ],
+                                    "id": "39aa1f38-f1cd-4389-8a10-37e91b6012a5",
+                                    "name": "fan-speed-5-000",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "d53c1cbe-b800-4ad4-90e2-20a74151ec2c",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "id": "0b61be46-e1a8-4031-9745-9350ce6a8fed",
+                                    "name": "fan-speed-5-020",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "77596065-33d3-4bd7-a850-3817b2fdc20c",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "80"
+                                        }
+                                    ],
+                                    "id": "15cdd8ab-c78f-4d30-93d2-3ff18faa0390",
+                                    "name": "fan-speed-5-080",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "13e38d04-00ba-4073-b95e-22473d5c1d43",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "60"
+                                        }
+                                    ],
+                                    "id": "8060e235-23c1-49b1-aa62-229983f3f9d2",
+                                    "name": "fan-speed-5-060",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "6ae9d25a-98fa-4d3c-854e-b345ab1ee8ad",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "40"
+                                        }
+                                    ],
+                                    "id": "2b7b4d0b-9b8f-44ad-bef9-1db3298c6e1b",
+                                    "name": "fan-speed-5-040",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "timer",
+                            "functionInstance": "fan-power",
+                            "id": "9cee70fb-0541-4bec-99dd-e231e3fa38a4",
+                            "schedulable": false,
+                            "type": "numeric",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "f9c9eb66-1e9f-4131-a982-795c4effc58c",
+                                            "key": "50",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0
+                                        }
+                                    ],
+                                    "id": "340adde0-70d5-48b5-8619-948a7b098a2a",
+                                    "name": "timer-1",
+                                    "range": {
+                                        "max": 1440,
+                                        "min": 0,
+                                        "step": 1
+                                    },
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "toggle",
+                            "functionInstance": "comfort-breeze",
+                            "id": "535a6c6f-13a5-4e7c-8aef-d26bfa080dd9",
+                            "schedulable": true,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "0f56d21e-bb9e-49a8-be85-343c7c4b7a00",
+                                            "key": "8",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "id": "e8ad9c61-2733-405f-8b27-e3032446654c",
+                                    "name": "disabled",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "af671fec-36d8-4bd6-9eca-8cb73258136b",
+                                            "key": "8",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "id": "13793ea4-8682-4901-994b-08d5bc46ea24",
+                                    "name": "enabled",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "fan-reverse",
+                            "functionInstance": "fan-reverse",
+                            "id": "ab596b48-3502-478d-88d9-47060a090828",
+                            "schedulable": false,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "f666b8cf-4a73-4ac3-9d5a-b90f87c9943e",
+                                            "key": "7",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "id": "d39fe935-3d6d-4af5-810b-71057923e7b0",
+                                    "name": "forward",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "5950e062-d9ef-4ec6-8423-22295ec0e1b0",
+                                            "key": "7",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "2"
+                                        }
+                                    ],
+                                    "hints": [
+                                        "voice-hidden"
+                                    ],
+                                    "id": "6ee8ea04-2263-4ee7-ae45-ad3b05c9cd85",
+                                    "name": "in-progress",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "5e463752-29f1-4ede-93f7-8ac73b00dfdf",
+                                            "key": "7",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "id": "8be96435-9fe7-415a-b965-6c2fe7f197ce",
+                                    "name": "reverse",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "id": "6da9eaf6-d22e-48f8-890c-cee12bf52732",
+                    "key": "fan",
+                    "updatedTimestampMs": 0,
+                    "version": 1
+                }
+            ],
+            "device": {
+                "defaultName": "Ceiling Fan",
+                "deviceClass": "ceiling-fan",
+                "manufacturerName": "Friendly Name 16 Decorators Collection",
+                "model": "",
+                "profileId": "d4ab40f7-cccb-4ad1-8f0d-87126897a00c",
+                "type": "device"
+            },
+            "functions": [
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "power",
+                    "functionInstance": "primary",
+                    "id": "7e87f3a9-8ac9-48b2-bcea-ba8edd8e5ca2",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "1cc87cdb-153d-437a-af40-5451a8285119",
+                                    "key": "1",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "d5caaab1-19a7-47c8-9244-9d4480380271",
+                            "name": "on",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "4c8268bc-3256-46e4-9354-aa47d623d4a1",
+                                    "key": "1",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "b5df2e5c-8c77-4d1d-b9ad-aaa0ac40fce4",
+                            "name": "off",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "error-flag",
+                    "functionInstance": "storage-error",
+                    "id": "c1c24bb0-b602-405f-80ff-264608cb0c58",
+                    "schedulable": false,
+                    "type": "boolean",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "847be297-c37c-4bfb-8d6f-4a709adc4fe4",
+                                    "key": "405",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0
+                                }
+                            ],
+                            "id": "faba93e6-05ef-4903-bf49-ce02d2fbc2bd",
+                            "name": "storage-error",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "error-flag",
+                    "functionInstance": "acz-error",
+                    "id": "96828943-0b9d-428e-9e99-5f103c261978",
+                    "schedulable": false,
+                    "type": "boolean",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "c8469c36-fced-4f3a-bb0d-2d1585f166f3",
+                                    "key": "406",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0
+                                }
+                            ],
+                            "id": "3da5e6b2-24ae-4cb9-9626-5c7d0c29e532",
+                            "name": "no-error",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                }
+            ],
+            "id": "60d8f4c8-a511-49ae-a152-e8f32b9e3622",
+            "updatedTimestampMs": 0,
+            "version": 1
+        },
+        "deviceId": "8db77a68e902eef2",
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 8",
+        "id": "4cad55ff-9dd3-4256-a8ea-7d0e2974c251",
+        "image": "",
+        "locale": "en_US",
+        "state": {
+            "metadeviceId": "4cad55ff-9dd3-4256-a8ea-7d0e2974c251",
+            "values": [
+                {
+                    "functionClass": "power",
+                    "functionInstance": "primary",
+                    "lastUpdateTime": 1710933649207,
+                    "value": "off"
+                },
+                {
+                    "functionClass": "error-flag",
+                    "functionInstance": "storage-error",
+                    "lastUpdateTime": 1710010152263,
+                    "value": false
+                },
+                {
+                    "functionClass": "error-flag",
+                    "functionInstance": "acz-error",
+                    "lastUpdateTime": 1710010971921,
+                    "value": false
+                },
+                {
+                    "functionClass": "wifi-ssid",
+                    "lastUpdateTime": 1710011049780,
+                    "value": "SSID0"
+                },
+                {
+                    "functionClass": "wifi-rssi",
+                    "lastUpdateTime": 1712401994526,
+                    "value": -46
+                },
+                {
+                    "functionClass": "wifi-steady-state",
+                    "lastUpdateTime": 1712401179594,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-setup-state",
+                    "lastUpdateTime": 1712401804030,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "498b2a4225e1"
+                },
+                {
+                    "functionClass": "geo-coordinates",
+                    "functionInstance": "system-device-location",
+                    "lastUpdateTime": 1710011992972
+                },
+                {
+                    "functionClass": "scheduler-flags",
+                    "lastUpdateTime": 1710011003655,
+                    "value": 0
+                },
+                {
+                    "functionClass": "available",
+                    "lastUpdateTime": 1712490082527,
+                    "value": false
+                },
+                {
+                    "functionClass": "visible",
+                    "lastUpdateTime": 1712490082527,
+                    "value": false
+                },
+                {
+                    "functionClass": "direct",
+                    "lastUpdateTime": 1712490082527,
+                    "value": false
+                },
+                {
+                    "functionClass": "ble-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "7a68e902eef2"
+                }
+            ]
+        },
+        "tag": "",
+        "typeId": "metadevice.device",
+        "updatedTimestampMs": 1708665397675,
+        "version": 1
+    },
+    {
+        "children": [
+            "80236543-3928-417b-8842-aca93b22d17b",
+            "71abc0b6-059b-4eaf-9c91-be22d765f87f"
+        ],
+        "createdTimestampMs": 1708659012727,
+        "description": {
+            "createdTimestampMs": 0,
+            "defaultImage": "ceiling-fan-vinings-icon",
+            "descriptions": [
+                {
+                    "createdTimestampMs": 0,
+                    "defaultImage": "ceiling-fan-vinings-icon",
+                    "descriptions": [],
+                    "device": {
+                        "defaultName": "Ceiling Light",
+                        "deviceClass": "light",
+                        "manufacturerName": "Friendly Name 16 Decorators Collection",
+                        "model": "",
+                        "type": "device"
+                    },
+                    "functions": [
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "brightness",
+                            "id": "acc24efd-6b5b-417e-acef-3055fac7cec1",
+                            "schedulable": true,
+                            "type": "numeric",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "59fdccc3-f7dd-4426-98bc-8234944d266d",
+                                            "key": "4",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0
+                                        }
+                                    ],
+                                    "id": "b755898b-5ac1-4f4d-84f6-d4f16d1f9747",
+                                    "name": "brightness",
+                                    "range": {
+                                        "max": 100,
+                                        "min": 1,
+                                        "step": 1
+                                    },
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "color-temperature",
+                            "id": "91d62b46-2296-4706-b147-8eef282dc3db",
+                            "schedulable": false,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "ae200aff-7013-45b1-867c-9fdb9b38e452",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "5000"
+                                        }
+                                    ],
+                                    "id": "a19754c6-cbde-4317-9a86-79224277309b",
+                                    "name": "5000K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "a1ed65f0-7d9b-4851-b615-54d8a70e590d",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "2700"
+                                        }
+                                    ],
+                                    "id": "8809d98b-68af-4d6c-ba5a-799bdb14141c",
+                                    "name": "2700K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "6d0cce0b-1e8d-43c4-bf02-d704a7dde524",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "3000"
+                                        }
+                                    ],
+                                    "id": "722731be-3737-4034-9bbb-9f4295b4a056",
+                                    "name": "3000K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "23f5c160-b7c9-4034-a2cb-7b111ad64eb6",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "4000"
+                                        }
+                                    ],
+                                    "id": "ac1a62e9-ab05-451a-817d-bdc8f128b244",
+                                    "name": "4000K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "1b089542-a293-4d69-b9bc-a9489028577a",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "3500"
+                                        }
+                                    ],
+                                    "id": "1a6c523e-c3d5-4110-80b6-e4da4d74b481",
+                                    "name": "3500K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "ed21d233-b38d-45ae-9b8b-02ca6c9e8be9",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "6500"
+                                        }
+                                    ],
+                                    "id": "43c078e4-ca62-48f7-83f4-5163cf51bc95",
+                                    "name": "6500K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "power",
+                            "functionInstance": "light-power",
+                            "id": "a5aaba54-a669-4a4d-8248-54afd0202116",
+                            "schedulable": true,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "f15cb5eb-52d2-4bf1-b58b-b03330c70650",
+                                            "key": "2",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "id": "5f06fac8-c990-44e0-a88c-84c77d8f8db6",
+                                    "name": "off",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "2e9d150e-398a-4f61-9aab-6acd5010dc18",
+                                            "key": "2",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "id": "3c2638d0-b4bf-4446-91db-9d448fa30025",
+                                    "name": "on",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "id": "2d555946-49a1-4c5a-92e7-aa17db309da5",
+                    "key": "light",
+                    "updatedTimestampMs": 0,
+                    "version": 1
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "defaultImage": "ceiling-fan-vinings-icon",
+                    "descriptions": [],
+                    "device": {
+                        "defaultName": "Ceiling Fan",
+                        "deviceClass": "fan",
+                        "manufacturerName": "Friendly Name 16 Decorators Collection",
+                        "model": "",
+                        "type": "device"
+                    },
+                    "functions": [
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "power",
+                            "functionInstance": "fan-power",
+                            "id": "a3856f01-4dcb-4782-aa14-e2ab71b49c2d",
+                            "schedulable": true,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "93fb1a6a-42f1-4b78-872b-197ee6028765",
+                                            "key": "3",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "id": "124a3fac-0713-4ccd-951c-1c8f04a19093",
+                                    "name": "off",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "d942af1f-16da-4bd9-b645-27b3f86f49b0",
+                                            "key": "3",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "id": "bfe3e6a1-0d34-48ba-996c-dd4ed1d718d0",
+                                    "name": "on",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "fan-speed",
+                            "functionInstance": "fan-speed",
+                            "id": "4d0615e9-779e-4eb6-a89a-da644a53d323",
+                            "schedulable": true,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "afa8a7fd-0247-4b41-a41a-ccdb8ca643b1",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "100"
+                                        }
+                                    ],
+                                    "id": "b8928f8c-35e9-4dc5-85dc-9e96b4bc8d5e",
+                                    "name": "fan-speed-5-100",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "059b47d1-08c6-42fe-87be-a654fa91a1e9",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "hints": [
+                                        "hidden"
+                                    ],
+                                    "id": "39aa1f38-f1cd-4389-8a10-37e91b6012a5",
+                                    "name": "fan-speed-5-000",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "d53c1cbe-b800-4ad4-90e2-20a74151ec2c",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "id": "0b61be46-e1a8-4031-9745-9350ce6a8fed",
+                                    "name": "fan-speed-5-020",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "77596065-33d3-4bd7-a850-3817b2fdc20c",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "80"
+                                        }
+                                    ],
+                                    "id": "15cdd8ab-c78f-4d30-93d2-3ff18faa0390",
+                                    "name": "fan-speed-5-080",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "13e38d04-00ba-4073-b95e-22473d5c1d43",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "60"
+                                        }
+                                    ],
+                                    "id": "8060e235-23c1-49b1-aa62-229983f3f9d2",
+                                    "name": "fan-speed-5-060",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "6ae9d25a-98fa-4d3c-854e-b345ab1ee8ad",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "40"
+                                        }
+                                    ],
+                                    "id": "2b7b4d0b-9b8f-44ad-bef9-1db3298c6e1b",
+                                    "name": "fan-speed-5-040",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "timer",
+                            "functionInstance": "fan-power",
+                            "id": "9cee70fb-0541-4bec-99dd-e231e3fa38a4",
+                            "schedulable": false,
+                            "type": "numeric",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "f9c9eb66-1e9f-4131-a982-795c4effc58c",
+                                            "key": "50",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0
+                                        }
+                                    ],
+                                    "id": "340adde0-70d5-48b5-8619-948a7b098a2a",
+                                    "name": "timer-1",
+                                    "range": {
+                                        "max": 1440,
+                                        "min": 0,
+                                        "step": 1
+                                    },
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "toggle",
+                            "functionInstance": "comfort-breeze",
+                            "id": "535a6c6f-13a5-4e7c-8aef-d26bfa080dd9",
+                            "schedulable": true,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "0f56d21e-bb9e-49a8-be85-343c7c4b7a00",
+                                            "key": "8",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "id": "e8ad9c61-2733-405f-8b27-e3032446654c",
+                                    "name": "disabled",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "af671fec-36d8-4bd6-9eca-8cb73258136b",
+                                            "key": "8",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "id": "13793ea4-8682-4901-994b-08d5bc46ea24",
+                                    "name": "enabled",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "fan-reverse",
+                            "functionInstance": "fan-reverse",
+                            "id": "ab596b48-3502-478d-88d9-47060a090828",
+                            "schedulable": false,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "f666b8cf-4a73-4ac3-9d5a-b90f87c9943e",
+                                            "key": "7",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "id": "d39fe935-3d6d-4af5-810b-71057923e7b0",
+                                    "name": "forward",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "5950e062-d9ef-4ec6-8423-22295ec0e1b0",
+                                            "key": "7",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "2"
+                                        }
+                                    ],
+                                    "hints": [
+                                        "voice-hidden"
+                                    ],
+                                    "id": "6ee8ea04-2263-4ee7-ae45-ad3b05c9cd85",
+                                    "name": "in-progress",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "5e463752-29f1-4ede-93f7-8ac73b00dfdf",
+                                            "key": "7",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "id": "8be96435-9fe7-415a-b965-6c2fe7f197ce",
+                                    "name": "reverse",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "id": "6da9eaf6-d22e-48f8-890c-cee12bf52732",
+                    "key": "fan",
+                    "updatedTimestampMs": 0,
+                    "version": 1
+                }
+            ],
+            "device": {
+                "defaultName": "Ceiling Fan",
+                "deviceClass": "ceiling-fan",
+                "manufacturerName": "Friendly Name 16 Decorators Collection",
+                "model": "",
+                "profileId": "d4ab40f7-cccb-4ad1-8f0d-87126897a00c",
+                "type": "device"
+            },
+            "functions": [
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "power",
+                    "functionInstance": "primary",
+                    "id": "7e87f3a9-8ac9-48b2-bcea-ba8edd8e5ca2",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "1cc87cdb-153d-437a-af40-5451a8285119",
+                                    "key": "1",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "d5caaab1-19a7-47c8-9244-9d4480380271",
+                            "name": "on",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "4c8268bc-3256-46e4-9354-aa47d623d4a1",
+                                    "key": "1",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "b5df2e5c-8c77-4d1d-b9ad-aaa0ac40fce4",
+                            "name": "off",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "error-flag",
+                    "functionInstance": "storage-error",
+                    "id": "c1c24bb0-b602-405f-80ff-264608cb0c58",
+                    "schedulable": false,
+                    "type": "boolean",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "847be297-c37c-4bfb-8d6f-4a709adc4fe4",
+                                    "key": "405",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0
+                                }
+                            ],
+                            "id": "faba93e6-05ef-4903-bf49-ce02d2fbc2bd",
+                            "name": "storage-error",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "error-flag",
+                    "functionInstance": "acz-error",
+                    "id": "96828943-0b9d-428e-9e99-5f103c261978",
+                    "schedulable": false,
+                    "type": "boolean",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "c8469c36-fced-4f3a-bb0d-2d1585f166f3",
+                                    "key": "406",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0
+                                }
+                            ],
+                            "id": "3da5e6b2-24ae-4cb9-9626-5c7d0c29e532",
+                            "name": "no-error",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                }
+            ],
+            "id": "60d8f4c8-a511-49ae-a152-e8f32b9e3622",
+            "updatedTimestampMs": 0,
+            "version": 1
+        },
+        "deviceId": "81005c3108184673",
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 5 Room",
+        "id": "7d1d7702-f19c-4271-935e-cc464ecdf60d",
+        "image": "",
+        "locale": "en_US",
+        "state": {
+            "metadeviceId": "7d1d7702-f19c-4271-935e-cc464ecdf60d",
+            "values": [
+                {
+                    "functionClass": "power",
+                    "functionInstance": "primary",
+                    "lastUpdateTime": 1713714934009,
+                    "value": "on"
+                },
+                {
+                    "functionClass": "error-flag",
+                    "functionInstance": "storage-error",
+                    "lastUpdateTime": 1713720154143,
+                    "value": false
+                },
+                {
+                    "functionClass": "error-flag",
+                    "functionInstance": "acz-error",
+                    "lastUpdateTime": 1713720330869,
+                    "value": false
+                },
+                {
+                    "functionClass": "wifi-ssid",
+                    "lastUpdateTime": 1713722466675,
+                    "value": "SSID0"
+                },
+                {
+                    "functionClass": "wifi-rssi",
+                    "lastUpdateTime": 1713733819460,
+                    "value": -45
+                },
+                {
+                    "functionClass": "wifi-steady-state",
+                    "lastUpdateTime": 1713732143105,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-setup-state",
+                    "lastUpdateTime": 1713732866261,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "5e2dc3520cfb"
+                },
+                {
+                    "functionClass": "geo-coordinates",
+                    "functionInstance": "system-device-location",
+                    "lastUpdateTime": 1713723366315,
+                    "value": {
+                        "geo-coordinates": {
+                            "latitude": "0.1368361169763389",
+                            "longitude": "0.555939958245533"
+                        }
+                    }
+                },
+                {
+                    "functionClass": "scheduler-flags",
+                    "lastUpdateTime": 1713721880926,
+                    "value": 0
+                },
+                {
+                    "functionClass": "available",
+                    "lastUpdateTime": 1713876698799,
+                    "value": true
+                },
+                {
+                    "functionClass": "visible",
+                    "lastUpdateTime": 1713876698799,
+                    "value": true
+                },
+                {
+                    "functionClass": "direct",
+                    "lastUpdateTime": 1713876698799,
+                    "value": true
+                },
+                {
+                    "functionClass": "ble-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "5c3108184673"
+                }
+            ]
+        },
+        "tag": "",
+        "typeId": "metadevice.device",
+        "updatedTimestampMs": 1710674197160,
+        "version": 1
+    },
+    {
+        "children": [
+            "4ade6ca1-5fd9-4540-8106-fa9fa40332d8",
+            "a66caf5f-3d97-4d92-8526-a3a169a3ef5c"
+        ],
+        "createdTimestampMs": 1708652876440,
+        "description": {
+            "createdTimestampMs": 0,
+            "defaultImage": "ceiling-fan-vinings-icon",
+            "descriptions": [
+                {
+                    "createdTimestampMs": 0,
+                    "defaultImage": "ceiling-fan-vinings-icon",
+                    "descriptions": [],
+                    "device": {
+                        "defaultName": "Ceiling Light",
+                        "deviceClass": "light",
+                        "manufacturerName": "Friendly Name 16 Decorators Collection",
+                        "model": "",
+                        "type": "device"
+                    },
+                    "functions": [
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "brightness",
+                            "id": "acc24efd-6b5b-417e-acef-3055fac7cec1",
+                            "schedulable": true,
+                            "type": "numeric",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "59fdccc3-f7dd-4426-98bc-8234944d266d",
+                                            "key": "4",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0
+                                        }
+                                    ],
+                                    "id": "b755898b-5ac1-4f4d-84f6-d4f16d1f9747",
+                                    "name": "brightness",
+                                    "range": {
+                                        "max": 100,
+                                        "min": 1,
+                                        "step": 1
+                                    },
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "color-temperature",
+                            "id": "91d62b46-2296-4706-b147-8eef282dc3db",
+                            "schedulable": false,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "ae200aff-7013-45b1-867c-9fdb9b38e452",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "5000"
+                                        }
+                                    ],
+                                    "id": "a19754c6-cbde-4317-9a86-79224277309b",
+                                    "name": "5000K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "a1ed65f0-7d9b-4851-b615-54d8a70e590d",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "2700"
+                                        }
+                                    ],
+                                    "id": "8809d98b-68af-4d6c-ba5a-799bdb14141c",
+                                    "name": "2700K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "6d0cce0b-1e8d-43c4-bf02-d704a7dde524",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "3000"
+                                        }
+                                    ],
+                                    "id": "722731be-3737-4034-9bbb-9f4295b4a056",
+                                    "name": "3000K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "23f5c160-b7c9-4034-a2cb-7b111ad64eb6",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "4000"
+                                        }
+                                    ],
+                                    "id": "ac1a62e9-ab05-451a-817d-bdc8f128b244",
+                                    "name": "4000K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "1b089542-a293-4d69-b9bc-a9489028577a",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "3500"
+                                        }
+                                    ],
+                                    "id": "1a6c523e-c3d5-4110-80b6-e4da4d74b481",
+                                    "name": "3500K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "ed21d233-b38d-45ae-9b8b-02ca6c9e8be9",
+                                            "key": "5",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "6500"
+                                        }
+                                    ],
+                                    "id": "43c078e4-ca62-48f7-83f4-5163cf51bc95",
+                                    "name": "6500K",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "power",
+                            "functionInstance": "light-power",
+                            "id": "a5aaba54-a669-4a4d-8248-54afd0202116",
+                            "schedulable": true,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "f15cb5eb-52d2-4bf1-b58b-b03330c70650",
+                                            "key": "2",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "id": "5f06fac8-c990-44e0-a88c-84c77d8f8db6",
+                                    "name": "off",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "2e9d150e-398a-4f61-9aab-6acd5010dc18",
+                                            "key": "2",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "id": "3c2638d0-b4bf-4446-91db-9d448fa30025",
+                                    "name": "on",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "id": "2d555946-49a1-4c5a-92e7-aa17db309da5",
+                    "key": "light",
+                    "updatedTimestampMs": 0,
+                    "version": 1
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "defaultImage": "ceiling-fan-vinings-icon",
+                    "descriptions": [],
+                    "device": {
+                        "defaultName": "Ceiling Fan",
+                        "deviceClass": "fan",
+                        "manufacturerName": "Friendly Name 16 Decorators Collection",
+                        "model": "",
+                        "type": "device"
+                    },
+                    "functions": [
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "power",
+                            "functionInstance": "fan-power",
+                            "id": "a3856f01-4dcb-4782-aa14-e2ab71b49c2d",
+                            "schedulable": true,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "93fb1a6a-42f1-4b78-872b-197ee6028765",
+                                            "key": "3",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "id": "124a3fac-0713-4ccd-951c-1c8f04a19093",
+                                    "name": "off",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "d942af1f-16da-4bd9-b645-27b3f86f49b0",
+                                            "key": "3",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "id": "bfe3e6a1-0d34-48ba-996c-dd4ed1d718d0",
+                                    "name": "on",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "fan-speed",
+                            "functionInstance": "fan-speed",
+                            "id": "4d0615e9-779e-4eb6-a89a-da644a53d323",
+                            "schedulable": true,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "afa8a7fd-0247-4b41-a41a-ccdb8ca643b1",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "100"
+                                        }
+                                    ],
+                                    "id": "b8928f8c-35e9-4dc5-85dc-9e96b4bc8d5e",
+                                    "name": "fan-speed-5-100",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "059b47d1-08c6-42fe-87be-a654fa91a1e9",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "hints": [
+                                        "hidden"
+                                    ],
+                                    "id": "39aa1f38-f1cd-4389-8a10-37e91b6012a5",
+                                    "name": "fan-speed-5-000",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "d53c1cbe-b800-4ad4-90e2-20a74151ec2c",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "20"
+                                        }
+                                    ],
+                                    "id": "0b61be46-e1a8-4031-9745-9350ce6a8fed",
+                                    "name": "fan-speed-5-020",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "77596065-33d3-4bd7-a850-3817b2fdc20c",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "80"
+                                        }
+                                    ],
+                                    "id": "15cdd8ab-c78f-4d30-93d2-3ff18faa0390",
+                                    "name": "fan-speed-5-080",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "13e38d04-00ba-4073-b95e-22473d5c1d43",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "60"
+                                        }
+                                    ],
+                                    "id": "8060e235-23c1-49b1-aa62-229983f3f9d2",
+                                    "name": "fan-speed-5-060",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "6ae9d25a-98fa-4d3c-854e-b345ab1ee8ad",
+                                            "key": "6",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "40"
+                                        }
+                                    ],
+                                    "id": "2b7b4d0b-9b8f-44ad-bef9-1db3298c6e1b",
+                                    "name": "fan-speed-5-040",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "timer",
+                            "functionInstance": "fan-power",
+                            "id": "9cee70fb-0541-4bec-99dd-e231e3fa38a4",
+                            "schedulable": false,
+                            "type": "numeric",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "f9c9eb66-1e9f-4131-a982-795c4effc58c",
+                                            "key": "50",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0
+                                        }
+                                    ],
+                                    "id": "340adde0-70d5-48b5-8619-948a7b098a2a",
+                                    "name": "timer-1",
+                                    "range": {
+                                        "max": 1440,
+                                        "min": 0,
+                                        "step": 1
+                                    },
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "toggle",
+                            "functionInstance": "comfort-breeze",
+                            "id": "535a6c6f-13a5-4e7c-8aef-d26bfa080dd9",
+                            "schedulable": true,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "0f56d21e-bb9e-49a8-be85-343c7c4b7a00",
+                                            "key": "8",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "id": "e8ad9c61-2733-405f-8b27-e3032446654c",
+                                    "name": "disabled",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "af671fec-36d8-4bd6-9eca-8cb73258136b",
+                                            "key": "8",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "id": "13793ea4-8682-4901-994b-08d5bc46ea24",
+                                    "name": "enabled",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "functionClass": "fan-reverse",
+                            "functionInstance": "fan-reverse",
+                            "id": "ab596b48-3502-478d-88d9-47060a090828",
+                            "schedulable": false,
+                            "type": "category",
+                            "updatedTimestampMs": 0,
+                            "values": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "f666b8cf-4a73-4ac3-9d5a-b90f87c9943e",
+                                            "key": "7",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "id": "d39fe935-3d6d-4af5-810b-71057923e7b0",
+                                    "name": "forward",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "5950e062-d9ef-4ec6-8423-22295ec0e1b0",
+                                            "key": "7",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "2"
+                                        }
+                                    ],
+                                    "hints": [
+                                        "voice-hidden"
+                                    ],
+                                    "id": "6ee8ea04-2263-4ee7-ae45-ad3b05c9cd85",
+                                    "name": "in-progress",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                },
+                                {
+                                    "createdTimestampMs": 0,
+                                    "deviceValues": [
+                                        {
+                                            "createdTimestampMs": 0,
+                                            "id": "5e463752-29f1-4ede-93f7-8ac73b00dfdf",
+                                            "key": "7",
+                                            "type": "attribute",
+                                            "updatedTimestampMs": 0,
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "id": "8be96435-9fe7-415a-b965-6c2fe7f197ce",
+                                    "name": "reverse",
+                                    "range": {},
+                                    "updatedTimestampMs": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "id": "6da9eaf6-d22e-48f8-890c-cee12bf52732",
+                    "key": "fan",
+                    "updatedTimestampMs": 0,
+                    "version": 1
+                }
+            ],
+            "device": {
+                "defaultName": "Ceiling Fan",
+                "deviceClass": "ceiling-fan",
+                "manufacturerName": "Friendly Name 16 Decorators Collection",
+                "model": "",
+                "profileId": "d4ab40f7-cccb-4ad1-8f0d-87126897a00c",
+                "type": "device"
+            },
+            "functions": [
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "power",
+                    "functionInstance": "primary",
+                    "id": "7e87f3a9-8ac9-48b2-bcea-ba8edd8e5ca2",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "1cc87cdb-153d-437a-af40-5451a8285119",
+                                    "key": "1",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "d5caaab1-19a7-47c8-9244-9d4480380271",
+                            "name": "on",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "4c8268bc-3256-46e4-9354-aa47d623d4a1",
+                                    "key": "1",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "b5df2e5c-8c77-4d1d-b9ad-aaa0ac40fce4",
+                            "name": "off",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "error-flag",
+                    "functionInstance": "storage-error",
+                    "id": "c1c24bb0-b602-405f-80ff-264608cb0c58",
+                    "schedulable": false,
+                    "type": "boolean",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "847be297-c37c-4bfb-8d6f-4a709adc4fe4",
+                                    "key": "405",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0
+                                }
+                            ],
+                            "id": "faba93e6-05ef-4903-bf49-ce02d2fbc2bd",
+                            "name": "storage-error",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "error-flag",
+                    "functionInstance": "acz-error",
+                    "id": "96828943-0b9d-428e-9e99-5f103c261978",
+                    "schedulable": false,
+                    "type": "boolean",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "c8469c36-fced-4f3a-bb0d-2d1585f166f3",
+                                    "key": "406",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0
+                                }
+                            ],
+                            "id": "3da5e6b2-24ae-4cb9-9626-5c7d0c29e532",
+                            "name": "no-error",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                }
+            ],
+            "id": "60d8f4c8-a511-49ae-a152-e8f32b9e3622",
+            "updatedTimestampMs": 0,
+            "version": 1
+        },
+        "deviceId": "8f8eea7c73f8d4ff",
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 14",
+        "id": "7d4aa3fa-d4b0-41e9-bd38-a16e912d7a6b",
+        "image": "",
+        "locale": "en_US",
+        "state": {
+            "metadeviceId": "7d4aa3fa-d4b0-41e9-bd38-a16e912d7a6b",
+            "values": [
+                {
+                    "functionClass": "power",
+                    "functionInstance": "primary",
+                    "lastUpdateTime": 1713707362377,
+                    "value": "on"
+                },
+                {
+                    "functionClass": "error-flag",
+                    "functionInstance": "storage-error",
+                    "lastUpdateTime": 1713709997268,
+                    "value": false
+                },
+                {
+                    "functionClass": "error-flag",
+                    "functionInstance": "acz-error",
+                    "lastUpdateTime": 1713710687525,
+                    "value": false
+                },
+                {
+                    "functionClass": "wifi-ssid",
+                    "lastUpdateTime": 1713711789519,
+                    "value": "SSID0"
+                },
+                {
+                    "functionClass": "wifi-rssi",
+                    "lastUpdateTime": 1713736061077,
+                    "value": -25
+                },
+                {
+                    "functionClass": "wifi-steady-state",
+                    "lastUpdateTime": 1713735267305,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-setup-state",
+                    "lastUpdateTime": 1713735415129,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "692983d53aa6"
+                },
+                {
+                    "functionClass": "geo-coordinates",
+                    "functionInstance": "system-device-location",
+                    "lastUpdateTime": 1713712144689
+                },
+                {
+                    "functionClass": "scheduler-flags",
+                    "lastUpdateTime": 1713710932221,
+                    "value": 0
+                },
+                {
+                    "functionClass": "available",
+                    "lastUpdateTime": 1713740070580,
+                    "value": true
+                },
+                {
+                    "functionClass": "visible",
+                    "lastUpdateTime": 1713740070580,
+                    "value": true
+                },
+                {
+                    "functionClass": "direct",
+                    "lastUpdateTime": 1713740070580,
+                    "value": true
+                },
+                {
+                    "functionClass": "ble-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "ea7c73f8d4ff"
+                }
+            ]
+        },
+        "tag": "",
+        "typeId": "metadevice.device",
+        "updatedTimestampMs": 1708656107669,
+        "version": 1
+    },
+    {
+        "children": [],
+        "createdTimestampMs": 1708665051198,
+        "description": {
+            "createdTimestampMs": 0,
+            "defaultImage": "ceiling-fan-vinings-icon",
+            "descriptions": [],
+            "device": {
+                "defaultName": "Ceiling Fan",
+                "deviceClass": "fan",
+                "manufacturerName": "Friendly Name 16 Decorators Collection",
+                "model": "",
+                "type": "device"
+            },
+            "functions": [
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "power",
+                    "functionInstance": "fan-power",
+                    "id": "a3856f01-4dcb-4782-aa14-e2ab71b49c2d",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "93fb1a6a-42f1-4b78-872b-197ee6028765",
+                                    "key": "3",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "124a3fac-0713-4ccd-951c-1c8f04a19093",
+                            "name": "off",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "d942af1f-16da-4bd9-b645-27b3f86f49b0",
+                                    "key": "3",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "bfe3e6a1-0d34-48ba-996c-dd4ed1d718d0",
+                            "name": "on",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "fan-speed",
+                    "functionInstance": "fan-speed",
+                    "id": "4d0615e9-779e-4eb6-a89a-da644a53d323",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "afa8a7fd-0247-4b41-a41a-ccdb8ca643b1",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "100"
+                                }
+                            ],
+                            "id": "b8928f8c-35e9-4dc5-85dc-9e96b4bc8d5e",
+                            "name": "fan-speed-5-100",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "059b47d1-08c6-42fe-87be-a654fa91a1e9",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "hints": [
+                                "hidden"
+                            ],
+                            "id": "39aa1f38-f1cd-4389-8a10-37e91b6012a5",
+                            "name": "fan-speed-5-000",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "d53c1cbe-b800-4ad4-90e2-20a74151ec2c",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "20"
+                                }
+                            ],
+                            "id": "0b61be46-e1a8-4031-9745-9350ce6a8fed",
+                            "name": "fan-speed-5-020",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "77596065-33d3-4bd7-a850-3817b2fdc20c",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "80"
+                                }
+                            ],
+                            "id": "15cdd8ab-c78f-4d30-93d2-3ff18faa0390",
+                            "name": "fan-speed-5-080",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "13e38d04-00ba-4073-b95e-22473d5c1d43",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "60"
+                                }
+                            ],
+                            "id": "8060e235-23c1-49b1-aa62-229983f3f9d2",
+                            "name": "fan-speed-5-060",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "6ae9d25a-98fa-4d3c-854e-b345ab1ee8ad",
+                                    "key": "6",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "40"
+                                }
+                            ],
+                            "id": "2b7b4d0b-9b8f-44ad-bef9-1db3298c6e1b",
+                            "name": "fan-speed-5-040",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "timer",
+                    "functionInstance": "fan-power",
+                    "id": "9cee70fb-0541-4bec-99dd-e231e3fa38a4",
+                    "schedulable": false,
+                    "type": "numeric",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "f9c9eb66-1e9f-4131-a982-795c4effc58c",
+                                    "key": "50",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0
+                                }
+                            ],
+                            "id": "340adde0-70d5-48b5-8619-948a7b098a2a",
+                            "name": "timer-1",
+                            "range": {
+                                "max": 1440,
+                                "min": 0,
+                                "step": 1
+                            },
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "toggle",
+                    "functionInstance": "comfort-breeze",
+                    "id": "535a6c6f-13a5-4e7c-8aef-d26bfa080dd9",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "0f56d21e-bb9e-49a8-be85-343c7c4b7a00",
+                                    "key": "8",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "e8ad9c61-2733-405f-8b27-e3032446654c",
+                            "name": "disabled",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "af671fec-36d8-4bd6-9eca-8cb73258136b",
+                                    "key": "8",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "13793ea4-8682-4901-994b-08d5bc46ea24",
+                            "name": "enabled",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "fan-reverse",
+                    "functionInstance": "fan-reverse",
+                    "id": "ab596b48-3502-478d-88d9-47060a090828",
+                    "schedulable": false,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "f666b8cf-4a73-4ac3-9d5a-b90f87c9943e",
+                                    "key": "7",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "d39fe935-3d6d-4af5-810b-71057923e7b0",
+                            "name": "forward",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "5950e062-d9ef-4ec6-8423-22295ec0e1b0",
+                                    "key": "7",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "2"
+                                }
+                            ],
+                            "hints": [
+                                "voice-hidden"
+                            ],
+                            "id": "6ee8ea04-2263-4ee7-ae45-ad3b05c9cd85",
+                            "name": "in-progress",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "5e463752-29f1-4ede-93f7-8ac73b00dfdf",
+                                    "key": "7",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "8be96435-9fe7-415a-b965-6c2fe7f197ce",
+                            "name": "reverse",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                }
+            ],
+            "id": "6da9eaf6-d22e-48f8-890c-cee12bf52732",
+            "key": "fan",
+            "updatedTimestampMs": 0,
+            "version": 1
+        },
+        "deviceId": "8db77a68e902eef2",
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 18",
+        "id": "8569cf0f-e7a3-432c-8be7-8497d5fb2de6",
+        "image": "",
+        "locale": "en_US",
+        "semanticDescriptionKey": "fan",
+        "state": {
+            "metadeviceId": "8569cf0f-e7a3-432c-8be7-8497d5fb2de6",
+            "values": [
+                {
+                    "functionClass": "power",
+                    "functionInstance": "fan-power",
+                    "lastUpdateTime": 1710934450251,
+                    "value": "off"
+                },
+                {
+                    "functionClass": "fan-speed",
+                    "functionInstance": "fan-speed",
+                    "lastUpdateTime": 1710008717358,
+                    "value": "fan-speed-5-060"
+                },
+                {
+                    "functionClass": "timer",
+                    "functionInstance": "fan-power",
+                    "lastUpdateTime": 1710009871203,
+                    "value": 0
+                },
+                {
+                    "functionClass": "toggle",
+                    "functionInstance": "comfort-breeze",
+                    "lastUpdateTime": 1710009615199,
+                    "value": "disabled"
+                },
+                {
+                    "functionClass": "fan-reverse",
+                    "functionInstance": "fan-reverse",
+                    "lastUpdateTime": 1710008843290,
+                    "value": "forward"
+                },
+                {
+                    "functionClass": "wifi-ssid",
+                    "lastUpdateTime": 1710011049780,
+                    "value": "SSID0"
+                },
+                {
+                    "functionClass": "wifi-rssi",
+                    "lastUpdateTime": 1712401994526,
+                    "value": -46
+                },
+                {
+                    "functionClass": "wifi-steady-state",
+                    "lastUpdateTime": 1712401179594,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-setup-state",
+                    "lastUpdateTime": 1712401804030,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "498b2a4225e1"
+                },
+                {
+                    "functionClass": "geo-coordinates",
+                    "functionInstance": "system-device-location",
+                    "lastUpdateTime": 1710011992972
+                },
+                {
+                    "functionClass": "scheduler-flags",
+                    "lastUpdateTime": 1710011003655,
+                    "value": 0
+                },
+                {
+                    "functionClass": "available",
+                    "lastUpdateTime": 1712490082527,
+                    "value": false
+                },
+                {
+                    "functionClass": "visible",
+                    "lastUpdateTime": 1712490082527,
+                    "value": false
+                },
+                {
+                    "functionClass": "direct",
+                    "lastUpdateTime": 1712490082527,
+                    "value": false
+                },
+                {
+                    "functionClass": "ble-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "7a68e902eef2"
+                }
+            ]
+        },
+        "tag": "",
+        "typeId": "metadevice.device",
+        "updatedTimestampMs": 1710676135092,
+        "version": 1
+    },
+    {
+        "children": [],
+        "createdTimestampMs": 1708659918250,
+        "description": {
+            "createdTimestampMs": 0,
+            "defaultImage": "ceiling-fan-vinings-icon",
+            "descriptions": [],
+            "device": {
+                "defaultName": "Ceiling Light",
+                "deviceClass": "light",
+                "manufacturerName": "Friendly Name 16 Decorators Collection",
+                "model": "",
+                "type": "device"
+            },
+            "functions": [
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "brightness",
+                    "id": "acc24efd-6b5b-417e-acef-3055fac7cec1",
+                    "schedulable": true,
+                    "type": "numeric",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "59fdccc3-f7dd-4426-98bc-8234944d266d",
+                                    "key": "4",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0
+                                }
+                            ],
+                            "id": "b755898b-5ac1-4f4d-84f6-d4f16d1f9747",
+                            "name": "brightness",
+                            "range": {
+                                "max": 100,
+                                "min": 1,
+                                "step": 1
+                            },
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "color-temperature",
+                    "id": "91d62b46-2296-4706-b147-8eef282dc3db",
+                    "schedulable": false,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "ae200aff-7013-45b1-867c-9fdb9b38e452",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "5000"
+                                }
+                            ],
+                            "id": "a19754c6-cbde-4317-9a86-79224277309b",
+                            "name": "5000K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "a1ed65f0-7d9b-4851-b615-54d8a70e590d",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "2700"
+                                }
+                            ],
+                            "id": "8809d98b-68af-4d6c-ba5a-799bdb14141c",
+                            "name": "2700K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "6d0cce0b-1e8d-43c4-bf02-d704a7dde524",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "3000"
+                                }
+                            ],
+                            "id": "722731be-3737-4034-9bbb-9f4295b4a056",
+                            "name": "3000K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "23f5c160-b7c9-4034-a2cb-7b111ad64eb6",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "4000"
+                                }
+                            ],
+                            "id": "ac1a62e9-ab05-451a-817d-bdc8f128b244",
+                            "name": "4000K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "1b089542-a293-4d69-b9bc-a9489028577a",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "3500"
+                                }
+                            ],
+                            "id": "1a6c523e-c3d5-4110-80b6-e4da4d74b481",
+                            "name": "3500K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "ed21d233-b38d-45ae-9b8b-02ca6c9e8be9",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "6500"
+                                }
+                            ],
+                            "id": "43c078e4-ca62-48f7-83f4-5163cf51bc95",
+                            "name": "6500K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "power",
+                    "functionInstance": "light-power",
+                    "id": "a5aaba54-a669-4a4d-8248-54afd0202116",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "f15cb5eb-52d2-4bf1-b58b-b03330c70650",
+                                    "key": "2",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "5f06fac8-c990-44e0-a88c-84c77d8f8db6",
+                            "name": "off",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "2e9d150e-398a-4f61-9aab-6acd5010dc18",
+                                    "key": "2",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "3c2638d0-b4bf-4446-91db-9d448fa30025",
+                            "name": "on",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                }
+            ],
+            "id": "2d555946-49a1-4c5a-92e7-aa17db309da5",
+            "key": "light",
+            "updatedTimestampMs": 0,
+            "version": 1
+        },
+        "deviceId": "81005c3108184673",
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 5 Room Light",
+        "id": "71abc0b6-059b-4eaf-9c91-be22d765f87f",
+        "image": "",
+        "locale": "en_US",
+        "semanticDescriptionKey": "light",
+        "state": {
+            "metadeviceId": "71abc0b6-059b-4eaf-9c91-be22d765f87f",
+            "values": [
+                {
+                    "functionClass": "brightness",
+                    "lastUpdateTime": 1713716768873,
+                    "value": 1
+                },
+                {
+                    "functionClass": "color-temperature",
+                    "lastUpdateTime": 1713717763099,
+                    "value": "3000K"
+                },
+                {
+                    "functionClass": "power",
+                    "functionInstance": "light-power",
+                    "lastUpdateTime": 1713715880348,
+                    "value": "off"
+                },
+                {
+                    "functionClass": "wifi-ssid",
+                    "lastUpdateTime": 1713722466675,
+                    "value": "SSID0"
+                },
+                {
+                    "functionClass": "wifi-rssi",
+                    "lastUpdateTime": 1713733819460,
+                    "value": -45
+                },
+                {
+                    "functionClass": "wifi-steady-state",
+                    "lastUpdateTime": 1713732143105,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-setup-state",
+                    "lastUpdateTime": 1713732866261,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "5e2dc3520cfb"
+                },
+                {
+                    "functionClass": "geo-coordinates",
+                    "functionInstance": "system-device-location",
+                    "lastUpdateTime": 1713723366315,
+                    "value": {
+                        "geo-coordinates": {
+                            "latitude": "0.1368361169763389",
+                            "longitude": "0.555939958245533"
+                        }
+                    }
+                },
+                {
+                    "functionClass": "scheduler-flags",
+                    "lastUpdateTime": 1713721880926,
+                    "value": 0
+                },
+                {
+                    "functionClass": "available",
+                    "lastUpdateTime": 1713876698799,
+                    "value": true
+                },
+                {
+                    "functionClass": "visible",
+                    "lastUpdateTime": 1713876698799,
+                    "value": true
+                },
+                {
+                    "functionClass": "direct",
+                    "lastUpdateTime": 1713876698799,
+                    "value": true
+                },
+                {
+                    "functionClass": "ble-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "5c3108184673"
+                }
+            ]
+        },
+        "tag": "",
+        "typeId": "metadevice.device",
+        "updatedTimestampMs": 1710676994885,
+        "version": 1
+    },
+    {
+        "children": [],
+        "createdTimestampMs": 1708664900428,
+        "description": {
+            "createdTimestampMs": 0,
+            "defaultImage": "ceiling-fan-vinings-icon",
+            "descriptions": [],
+            "device": {
+                "defaultName": "Ceiling Light",
+                "deviceClass": "light",
+                "manufacturerName": "Friendly Name 16 Decorators Collection",
+                "model": "",
+                "type": "device"
+            },
+            "functions": [
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "brightness",
+                    "id": "acc24efd-6b5b-417e-acef-3055fac7cec1",
+                    "schedulable": true,
+                    "type": "numeric",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "59fdccc3-f7dd-4426-98bc-8234944d266d",
+                                    "key": "4",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0
+                                }
+                            ],
+                            "id": "b755898b-5ac1-4f4d-84f6-d4f16d1f9747",
+                            "name": "brightness",
+                            "range": {
+                                "max": 100,
+                                "min": 1,
+                                "step": 1
+                            },
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "color-temperature",
+                    "id": "91d62b46-2296-4706-b147-8eef282dc3db",
+                    "schedulable": false,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "ae200aff-7013-45b1-867c-9fdb9b38e452",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "5000"
+                                }
+                            ],
+                            "id": "a19754c6-cbde-4317-9a86-79224277309b",
+                            "name": "5000K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "a1ed65f0-7d9b-4851-b615-54d8a70e590d",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "2700"
+                                }
+                            ],
+                            "id": "8809d98b-68af-4d6c-ba5a-799bdb14141c",
+                            "name": "2700K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "6d0cce0b-1e8d-43c4-bf02-d704a7dde524",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "3000"
+                                }
+                            ],
+                            "id": "722731be-3737-4034-9bbb-9f4295b4a056",
+                            "name": "3000K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "23f5c160-b7c9-4034-a2cb-7b111ad64eb6",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "4000"
+                                }
+                            ],
+                            "id": "ac1a62e9-ab05-451a-817d-bdc8f128b244",
+                            "name": "4000K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "1b089542-a293-4d69-b9bc-a9489028577a",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "3500"
+                                }
+                            ],
+                            "id": "1a6c523e-c3d5-4110-80b6-e4da4d74b481",
+                            "name": "3500K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "ed21d233-b38d-45ae-9b8b-02ca6c9e8be9",
+                                    "key": "5",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "6500"
+                                }
+                            ],
+                            "id": "43c078e4-ca62-48f7-83f4-5163cf51bc95",
+                            "name": "6500K",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                },
+                {
+                    "createdTimestampMs": 0,
+                    "functionClass": "power",
+                    "functionInstance": "light-power",
+                    "id": "a5aaba54-a669-4a4d-8248-54afd0202116",
+                    "schedulable": true,
+                    "type": "category",
+                    "updatedTimestampMs": 0,
+                    "values": [
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "f15cb5eb-52d2-4bf1-b58b-b03330c70650",
+                                    "key": "2",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "0"
+                                }
+                            ],
+                            "id": "5f06fac8-c990-44e0-a88c-84c77d8f8db6",
+                            "name": "off",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        },
+                        {
+                            "createdTimestampMs": 0,
+                            "deviceValues": [
+                                {
+                                    "createdTimestampMs": 0,
+                                    "id": "2e9d150e-398a-4f61-9aab-6acd5010dc18",
+                                    "key": "2",
+                                    "type": "attribute",
+                                    "updatedTimestampMs": 0,
+                                    "value": "1"
+                                }
+                            ],
+                            "id": "3c2638d0-b4bf-4446-91db-9d448fa30025",
+                            "name": "on",
+                            "range": {},
+                            "updatedTimestampMs": 0
+                        }
+                    ]
+                }
+            ],
+            "id": "2d555946-49a1-4c5a-92e7-aa17db309da5",
+            "key": "light",
+            "updatedTimestampMs": 0,
+            "version": 1
+        },
+        "deviceId": "8db77a68e902eef2",
+        "friendlyDescription": "",
+        "friendlyName": "Friendly Name 3",
+        "id": "63277020-89ea-4218-9826-91ea58bc6b04",
+        "image": "",
+        "locale": "en_US",
+        "semanticDescriptionKey": "light",
+        "state": {
+            "metadeviceId": "63277020-89ea-4218-9826-91ea58bc6b04",
+            "values": [
+                {
+                    "functionClass": "brightness",
+                    "lastUpdateTime": 1710008488780,
+                    "value": 1
+                },
+                {
+                    "functionClass": "color-temperature",
+                    "lastUpdateTime": 1710008635014,
+                    "value": "3000K"
+                },
+                {
+                    "functionClass": "power",
+                    "functionInstance": "light-power",
+                    "lastUpdateTime": 1710007927529,
+                    "value": "off"
+                },
+                {
+                    "functionClass": "wifi-ssid",
+                    "lastUpdateTime": 1710011049780,
+                    "value": "SSID0"
+                },
+                {
+                    "functionClass": "wifi-rssi",
+                    "lastUpdateTime": 1712401994526,
+                    "value": -46
+                },
+                {
+                    "functionClass": "wifi-steady-state",
+                    "lastUpdateTime": 1712401179594,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-setup-state",
+                    "lastUpdateTime": 1712401804030,
+                    "value": "connected"
+                },
+                {
+                    "functionClass": "wifi-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "498b2a4225e1"
+                },
+                {
+                    "functionClass": "geo-coordinates",
+                    "functionInstance": "system-device-location",
+                    "lastUpdateTime": 1710011992972
+                },
+                {
+                    "functionClass": "scheduler-flags",
+                    "lastUpdateTime": 1710011003655,
+                    "value": 0
+                },
+                {
+                    "functionClass": "available",
+                    "lastUpdateTime": 1712490082527,
+                    "value": false
+                },
+                {
+                    "functionClass": "visible",
+                    "lastUpdateTime": 1712490082527,
+                    "value": false
+                },
+                {
+                    "functionClass": "direct",
+                    "lastUpdateTime": 1712490082527,
+                    "value": false
+                },
+                {
+                    "functionClass": "ble-mac-address",
+                    "lastUpdateTime": 0,
+                    "value": "7a68e902eef2"
+                }
+            ]
+        },
+        "tag": "",
+        "typeId": "metadevice.device",
+        "updatedTimestampMs": 1710675499894,
+        "version": 1
+    }
+]


### PR DESCRIPTION
Added support for [Vinwood Fan](https://www.homedepot.com/p/Home-Decorators-Collection-Vinwood-56-in-Indoor-White-Color-Changing-LED-Brushed-Nickel-Smart-Hubspace-Ceiling-Fan-with-Remote-Control-56002/320816365)

- Supports only supports brightness for ceiling fan light
- Added sample json file for Vinwood Fan

<img width="564" alt="Screenshot 2024-04-24 at 2 26 00 AM" src="https://github.com/jdeath/Hubspace-Homeassistant/assets/6324892/665e0e10-8d42-44cf-9f49-eec1e598955c">
<img width="566" alt="Screenshot 2024-04-24 at 2 26 29 AM" src="https://github.com/jdeath/Hubspace-Homeassistant/assets/6324892/42e74739-f5d1-4003-ae4e-401306eae2ca">
