### PR TITLE
Avoid logging issue at startup when the attribute is not (yet) resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ fan:
       living_room_fan:
         friendly_name: "Fan"
         value_template: "{{ states('light.ceilingfan_fan') }}"
-        percentage_template: "{{ (state_attr('light.ceilingfan_fan', 'brightness') / 255 * 100) | int }}"
+        percentage_template: "{{ ((state_attr('light.ceilingfan_fan', 'brightness') | int(0)) / 255 * 100) | int }}"
         turn_on:
           service: homeassistant.turn_on
           entity_id: light.ceilingfan_fan


### PR DESCRIPTION
- At startup, the attribute has a value of None, which errors, and using a default value of 0 avoids startup errors. 
TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'