### PR TITLE
Fix availability

### DIFF
--- a/custom_components/hubspace/fan.py
+++ b/custom_components/hubspace/fan.py
@@ -41,6 +41,7 @@ class HubspaceFan(CoordinatorEntity, FanEntity):
     :ivar _preset_modes: List of available preset modes for the device
     :ivar _supported_features: Features that the fan supports, where each
         feature is an Enum from FanEntityFeature.
+    :ivar _availability: If the device is available within HubSpace
     :ivar _fan_speeds: List of available fan speeds for the device from HubSpace
     :ivar _bonus_attrs: Attributes relayed to Home Assistant that do not need to be
         tracked in their own class variables
@@ -76,6 +77,7 @@ class HubspaceFan(CoordinatorEntity, FanEntity):
         self._preset_mode: Optional[str] = None
         self._preset_modes: set[str] = set()
         self._supported_features: FanEntityFeature = FanEntityFeature(0)
+        self._availability: Optional[bool] = None
         self._fan_speeds: list[Union[str, int]] = []
         self._fan_speed: Optional[str] = None
         self._bonus_attrs = {
@@ -141,7 +143,6 @@ class HubspaceFan(CoordinatorEntity, FanEntity):
         additional_attrs = [
             "wifi-ssid",
             "wifi-mac-address",
-            "available",
             "ble-mac-address",
         ]
         # functionClass -> internal attribute
@@ -172,6 +173,10 @@ class HubspaceFan(CoordinatorEntity, FanEntity):
     def unique_id(self) -> str:
         """Return the display name of this light."""
         return self._child_id
+
+    @property
+    def available(self) -> bool:
+        return self._availability is True
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -95,6 +95,7 @@ class HubspaceLight(CoordinatorEntity, LightEntity):
     :ivar _state: If the device is on / off
     :ivar _bonus_attrs: Attributes relayed to Home Assistant that do not need to be
         tracked in their own class variables
+    :ivar _availability: If the device is available within HubSpace
     :ivar _instance_attrs: Additional attributes that are required when
         POSTing to HubSpace
     :ivar _color_modes: Supported options for the light
@@ -137,6 +138,7 @@ class HubspaceLight(CoordinatorEntity, LightEntity):
             "deviceId": device_id,
             "Child ID": self._child_id,
         }
+        self._availability: Optional[bool] = None
         self._instance_attrs: dict[str, str] = {}
         # Entity-specific
         self._color_modes: set[ColorMode] = set()
@@ -273,6 +275,8 @@ class HubspaceLight(CoordinatorEntity, LightEntity):
                 self._current_effect = state.value
             elif state.functionClass in additional_attrs:
                 self._bonus_attrs[state.functionClass] = state.value
+            elif state.functionClass == "available":
+                self._availability = state.value
 
     @property
     def should_poll(self):
@@ -288,6 +292,10 @@ class HubspaceLight(CoordinatorEntity, LightEntity):
     def unique_id(self) -> str:
         """Return the display name of this light."""
         return self._child_id
+
+    @property
+    def available(self) -> bool:
+        return self._availability is True
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/hubspace/switch.py
+++ b/custom_components/hubspace/switch.py
@@ -25,6 +25,7 @@ class HubSpaceSwitch(CoordinatorEntity, SwitchEntity):
     :ivar _state: If the device is on / off
     :ivar _bonus_attrs: Attributes relayed to Home Assistant that do not need to be
         tracked in their own class variables
+    :ivar _availability: If the device is available within HubSpace
     :ivar _device_class: Device class used during lookup
     :ivar _instance: functionInstance within the HS device
     """
@@ -50,6 +51,7 @@ class HubSpaceSwitch(CoordinatorEntity, SwitchEntity):
             "deviceId": device_id,
             "Child ID": self._child_id,
         }
+        self._availability: Optional[bool] = None
         # Entity-specific
         self._device_class = device_class
         self._instance = instance
@@ -71,7 +73,9 @@ class HubSpaceSwitch(CoordinatorEntity, SwitchEntity):
             )
         # functionClass -> internal attribute
         for state in states:
-            if state.functionClass != "power":
+            if state.functionClass == "available":
+                self._availability = state.value
+            elif state.functionClass != "power":
                 continue
             if not self._instance:
                 self._state = state.value
@@ -97,6 +101,10 @@ class HubSpaceSwitch(CoordinatorEntity, SwitchEntity):
             return f"{self._child_id}-{self._instance}"
         else:
             return self._child_id
+
+    @property
+    def available(self) -> bool:
+        return self._availability is True
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/hubspace/valve.py
+++ b/custom_components/hubspace/valve.py
@@ -29,6 +29,7 @@ class HubSpaceValve(CoordinatorEntity, ValveEntity):
     :ivar _state: If the device is on / off
     :ivar _bonus_attrs: Attributes relayed to Home Assistant that do not need to be
         tracked in their own class variables
+    :ivar _availability: If the device is available within HubSpace
     :ivar _instance: functionInstance within the HS device
     :ivar _current_valve_position: Current position of the valve
     :ivar _reports_position: Reports position of the valve
@@ -54,6 +55,7 @@ class HubSpaceValve(CoordinatorEntity, ValveEntity):
             "deviceId": device_id,
             "Child ID": self._child_id,
         }
+        self._availability: Optional[bool] = None
         # Entity-specific
         # Assume that all HubSpace devices allow for open / close
         self._supported_features: ValveEntityFeature = (
@@ -80,7 +82,9 @@ class HubSpaceValve(CoordinatorEntity, ValveEntity):
             )
         # functionClass -> internal attribute
         for state in states:
-            if state.functionClass != "toggle":
+            if state.functionClass == "available":
+                self._availability = state.value
+            elif state.functionClass != "toggle":
                 continue
             if not self._instance:
                 self._state = state.value
@@ -106,6 +110,10 @@ class HubSpaceValve(CoordinatorEntity, ValveEntity):
             return f"{self._child_id}-{self._instance}"
         else:
             return self._child_id
+
+    @property
+    def available(self) -> bool:
+        return self._availability is True
 
     @property
     def supported_features(self) -> ValveEntityFeature:

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -89,7 +89,6 @@ class Test_HubSpaceFan:
                     "Child ID": None,
                     "wifi-ssid": "71e7209f-b932-44b9-ba2f-a8179f68c3ac",
                     "wifi-mac-address": "e1119e0a-688d-45df-9882-a76549db9bc3",
-                    "available": True,
                     "ble-mac-address": "07346a23-350b-4606-8d86-67217ec7a688",
                 },
             ),


### PR DESCRIPTION
Home Assistant shows entity availability based on HubSpace availability. When a device is unavailable in HubSpace, you cannot interact with it in Home Assistant.

![image](https://github.com/user-attachments/assets/250f4008-5749-4680-adbb-ec18b20d578c)
