### PR TITLE
Fix for #148 white not appearing for lights

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ are as follows:
 
 ## Changelog
 
+ * dev-fix-white-light
+
+   * Add white color mode to lights
+   * Update aioafero==2.0.1
+
  * 4.5.0
 
    * Convert to aioafero==2.0.0

--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -172,7 +172,7 @@ def get_color_mode(resource: Light, supported_modes: set[ColorMode]) -> ColorMod
         elif ColorMode.BRIGHTNESS in supported_modes:
             return ColorMode.BRIGHTNESS
         else:
-            return ColorMode.ONOFF
+            return ColorMode.WHITE
     else:
         return list(supported_modes)[-1] if len(supported_modes) else ColorMode.ONOFF
 

--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -39,6 +39,8 @@ class HubspaceLight(HubspaceBaseEntity, LightEntity):
             supported_color_modes.add(ColorMode.COLOR_TEMP)
         if self.resource.supports_dimming:
             supported_color_modes.add(ColorMode.BRIGHTNESS)
+        if self.resource.supports_color_white:
+            supported_color_modes.add(ColorMode.WHITE)
         self._attr_supported_color_modes = filter_supported_color_modes(
             supported_color_modes
         )

--- a/custom_components/hubspace/manifest.json
+++ b/custom_components/hubspace/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jdeath/Hubspace-Homeassistant/issues",
   "loggers": ["aioafero"],
-  "requirements": ["aioafero==2.0.0", "aiofiles"],
-  "version": "4.5.0"
+  "requirements": ["aioafero==2.0.1", "aiofiles"],
+  "version": "4.5.1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 homeassistant
-aioafero>=2.0.0
+aioafero>=2.0.1
 aiofiles>=24.1.0

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -76,7 +76,7 @@ async def mocked_dimmer(mocked_entry):
             ColorMode.BRIGHTNESS,
         ),
         # White - fallback
-        ("white", set(), ColorMode.ONOFF),
+        ("white", set(), ColorMode.WHITE),
         # Just fallback
         (None, set(), ColorMode.ONOFF),
     ],

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -54,7 +54,6 @@ async def mocked_dimmer(mocked_entry):
     await bridge.close()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "color_mode, supported, expected",
     [

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -25,6 +25,7 @@ rgb_temp_light = create_devices_from_data("light-rgb_temp.json")[0]
 light_a21 = create_devices_from_data("light-a21.json")[0]
 light_a21_id = "light.friendly_device_53_light"
 rgbw_led_strip = create_devices_from_data("rgbw-led-strip.json")[0]
+rgbw_led_strip_id = "light.friendly_device_6_light"
 
 
 @pytest.fixture
@@ -95,6 +96,7 @@ def test_get_color_mode(color_mode, supported, expected, mocked_entity):
     "dev,expected_entities",
     [
         (light_a21, [light_a21_id]),
+        (rgbw_led_strip, [rgbw_led_strip_id]),
     ],
 )
 async def test_async_setup_entry(dev, expected_entities, mocked_entry):


### PR DESCRIPTION
Fix for #148 

 * Goto HACS within HA
 * Click `Hubspace-HomeAssistant`
 * Click the triple dots on the top-left
 * Click `Update Information`
 *  Click the triple dots on the top-left
 * Click `Redownload`
 * Click `Show beta versions`
 * Select `dev-fix-white-light`
 * Click `DOWNLOAD`
 * Restart HA


Let me know if the issues persist after using this beta version.