### PR TITLE
Hide sensitive information

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ are as follows:
 
 ## Changelog
 
+ * 5.1.0
+
+   * Permanently hide secrets within HA logs
+
  * 5.0.0
 
    * BREAK: Binary Sensor names are more accurate but have new entity IDs

--- a/custom_components/hubspace/__init__.py
+++ b/custom_components/hubspace/__init__.py
@@ -126,7 +126,7 @@ async def perform_v4_migration(hass: HomeAssistant, config_entry: ConfigEntry) -
     except InvalidAuth:
         config_entry.async_start_reauth(hass)
         return False
-    data[CONF_TOKEN] = api.refresh_token
+    data[CONF_TOKEN] = api._auth._token_data.refresh_token
     # Previous versions may have used None for the unique ID
     unique_id = config_entry.data[CONF_USERNAME].lower()
     hass.config_entries.async_update_entry(

--- a/custom_components/hubspace/config_flow.py
+++ b/custom_components/hubspace/config_flow.py
@@ -76,7 +76,7 @@ class HubspaceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             err_type = "unknown"
         finally:
             await self.bridge.close()
-        return auth_result(self.bridge.refresh_token, err_type)
+        return auth_result(self.bridge._auth._token_data.refresh_token, err_type)
 
     @staticmethod
     def extract_user_data(user_input: dict[str, Any] | None) -> tuple[dict, dict]:

--- a/custom_components/hubspace/manifest.json
+++ b/custom_components/hubspace/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jdeath/Hubspace-Homeassistant/issues",
   "loggers": ["aioafero"],
-  "requirements": ["aioafero==3.0.2", "aiofiles"],
-  "version": "5.0.0"
+  "requirements": ["aioafero==3.1.0", "aiofiles"],
+  "version": "5.1.0"
 }

--- a/custom_components/hubspace/manifest.json
+++ b/custom_components/hubspace/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jdeath/Hubspace-Homeassistant/issues",
   "loggers": ["aioafero"],
-  "requirements": ["aioafero==3.1.0", "aiofiles"],
+  "requirements": ["aioafero==3.1.1", "aiofiles"],
   "version": "5.1.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 homeassistant
-aioafero>=3.0.0
+aioafero>=3.1.1
 aiofiles>=24.1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,9 +35,8 @@ async def mocked_bridge(mocker) -> v1.AferoBridgeV1:
     mocker.patch.object(hs_bridge, "initialize", side_effect=mocker.AsyncMock())
     mocker.patch.object(hs_bridge, "close", side_effect=mocker.AsyncMock())
     hs_bridge._auth._token_data = token_data(
-        "mock-token", expiration=datetime.datetime.now().timestamp() + 200
+        "mock-token", "mock-access", "mock-refresh-token", expiration=datetime.datetime.now().timestamp() + 200
     )
-    hs_bridge._auth._refresh_token = "mock-refresh-token"
     # Force initialization so test elements are not overwritten
     for controller in hs_bridge._controllers:
         controller._initialized = True


### PR DESCRIPTION
Ensure no sensitive information (email addresses are not sensitive and can easily be redacted by users) shows up in the HA logs.

Getting a token
```
URL: https://accounts.hubspaceconnect.com/auth/realms/thd/protocol/openid-connect/token
	data: {'grant_type': 'refresh_token', 'refresh_token': 'ey***WQ', 'scope': 'openid email offline_access profile', 'client_id': 'hubspace_android'}
	headers: {'Content-Type': 'application/x-www-form-urlencoded', 'user-agent': 'Dart/2.15 (dart:io)', 'host': 'accounts.hubspaceconnect.com'}
<snip>
JSON response: {'access_token': 'ey***HA', 'expires_in': 120, 'refresh_expires_in': 0, 'refresh_token': 'ey***dg', 'token_type': 'Bearer', 'id_token': 'ey***zQ', 'not-before-policy': 0, 'session_state': 'b1ba10b6-a9aa-445d-b673-a1b79468ff17', 'scope': 'openid email offline_access profile'}
```

Getting device information
```
Making request [get] to https://api2.afero.net/v1/accounts/93***07/metadevices with {'headers': {'host': 'semantics2.afero.net'}, 'params': {'expansions': 'state'}}
```