### PR TITLE
Add Alarm Panel Support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.12"
+#          - "3.12"
           - "3.13"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-#          - "3.12"
           - "3.13"
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -69,13 +69,17 @@ are as follows:
 
 ## Changelog
 
+- dev-5.4.0
+
+  - Implement Alarm Panels (#168)
+
 - 5.3.1
 
-  - Fixed an issue where a failure during auth produced an Unhandled exception
+  - Fixed an issue where a failure during auth produced an Unhandled exception (#169)
 
 - 5.3.0
 
-  - Add support for Portable ACs
+  - Add support for Portable ACs (#162)
   - Update climate devices to adjust more closely to Hubspace
   - Fix an issue where Thermostats could incorrectly use Auto
 
@@ -85,7 +89,7 @@ are as follows:
 
 - 5.2.2
 
-  - Fix battery percentage not showing
+  - Fix battery percentage not showing (#164)
 
 - 5.2.1
 

--- a/custom_components/hubspace/alarm_control_panel.py
+++ b/custom_components/hubspace/alarm_control_panel.py
@@ -1,0 +1,129 @@
+"""Home Assistant entity for interacting with Afero security-system."""
+
+from functools import partial
+
+from aioafero.v1 import AferoBridgeV1, SecuritySystemController
+from aioafero.v1.controllers.event import EventType
+from aioafero.v1.models import SecuritySystem
+from homeassistant.components.alarm_control_panel import (
+    AlarmControlPanelEntity,
+    AlarmControlPanelEntityFeature,
+    AlarmControlPanelState,
+    CodeFormat,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .bridge import HubspaceBridge
+from .const import DOMAIN
+from .entity import HubspaceBaseEntity, update_decorator
+
+
+class HubspaceSecuritySystem(HubspaceBaseEntity, AlarmControlPanelEntity):
+    """Representation of an Afero Security System."""
+
+    def __init__(
+        self,
+        bridge: HubspaceBridge,
+        controller: SecuritySystemController,
+        resource: SecuritySystem,
+    ) -> None:
+        """Initialize an Afero Security System."""
+
+        super().__init__(bridge, controller, resource)
+        self._supported_features: AlarmControlPanelEntityFeature = (
+            AlarmControlPanelEntityFeature(0)
+        )
+        if resource.supports_away:
+            self._supported_features += AlarmControlPanelEntityFeature.ARM_AWAY
+        if resource.supports_home:
+            self._supported_features += AlarmControlPanelEntityFeature.ARM_HOME
+        if resource.supports_trigger:
+            self._supported_features += AlarmControlPanelEntityFeature.TRIGGER
+
+    @property
+    def supported_features(self) -> AlarmControlPanelEntityFeature:
+        """Get all supported features."""
+        return self._supported_features
+
+    @property
+    def code_arm_required(self) -> bool:
+        """States if the code is required to arm the system."""
+        return False
+
+    @property
+    def code_format(self) -> CodeFormat | None:
+        """Format for PIN."""
+        return CodeFormat.NUMBER
+
+    @update_decorator
+    async def async_alarm_disarm(self, code: str | None = None) -> None:
+        """Send disarm command."""
+        await self.bridge.async_request_call(
+            self.controller.disarm,
+            device_id=self.resource.id,
+        )
+
+    @update_decorator
+    async def async_alarm_arm_home(self, code: str | None = None) -> None:
+        """Send arm home command."""
+        await self.bridge.async_request_call(
+            self.controller.arm_home,
+            device_id=self.resource.id,
+        )
+
+    @update_decorator
+    async def async_alarm_arm_away(self, code: str | None = None) -> None:
+        """Send arm away command."""
+        await self.bridge.async_request_call(
+            self.controller.arm_away,
+            device_id=self.resource.id,
+        )
+
+    @update_decorator
+    async def async_alarm_trigger(self, code: str | None = None) -> None:
+        """Send alarm trigger command."""
+        await self.bridge.async_request_call(
+            self.controller.alarm_trigger,
+            device_id=self.resource.id,
+        )
+
+    @property
+    def alarm_state(self) -> AlarmControlPanelState | None:
+        """Return the current state of the system."""
+        mapping = {
+            "arm-away": AlarmControlPanelState.ARMED_AWAY,
+            "alarming": AlarmControlPanelState.TRIGGERED,
+            "alarming-sos": AlarmControlPanelState.TRIGGERED,
+            "arm-stay": AlarmControlPanelState.ARMED_HOME,
+            "arm-started-stay": AlarmControlPanelState.ARMING,
+            "disarmed": AlarmControlPanelState.DISARMED,
+            "triggered": AlarmControlPanelState.PENDING,
+            "arm-started-away": AlarmControlPanelState.ARMING,
+        }
+        return mapping.get(self.resource.alarm_state.mode)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up entities."""
+    bridge: HubspaceBridge = hass.data[DOMAIN][config_entry.entry_id]
+    api: AferoBridgeV1 = bridge.api
+    controller: SecuritySystemController = api.security_systems
+    make_entity = partial(HubspaceSecuritySystem, bridge, controller)
+
+    @callback
+    def async_add_entity(event_type: EventType, resource: SecuritySystem) -> None:
+        """Add an entity."""
+        async_add_entities([make_entity(resource)])
+
+    # add all current items in controller
+    async_add_entities([make_entity(entity) for entity in controller])
+    # register listener for new entities
+    config_entry.async_on_unload(
+        controller.subscribe(async_add_entity, event_filter=EventType.RESOURCE_ADDED)
+    )

--- a/custom_components/hubspace/bridge.py
+++ b/custom_components/hubspace/bridge.py
@@ -74,7 +74,7 @@ class HubspaceBridge:
         setup_ok = False
 
         # Dev mocking
-        # self.api.fetch_data = mock_get_data("portable-ac-raw.json")
+        # self.api.fetch_data = mock_get_data("security-system-raw.json")
 
         try:
             async with asyncio.timeout(self.config_entry.options[CONF_TIMEOUT]):

--- a/custom_components/hubspace/const.py
+++ b/custom_components/hubspace/const.py
@@ -47,6 +47,7 @@ PLATFORMS: Final[list[Platform]] = [
     Platform.VALVE,
     Platform.NUMBER,
     Platform.SELECT,
+    Platform.ALARM_CONTROL_PANEL,
 ]
 
 
@@ -114,6 +115,15 @@ SENSORS_GENERAL = {
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
         state_class=SensorStateClass.MEASUREMENT,
+    ),
+    # Security System
+    "history-event": SensorEntityDescription(
+        key="history-event",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    "disarmed-by": SensorEntityDescription(
+        key="disarmed-by",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
 }
 
@@ -188,6 +198,17 @@ BINARY_SENSORS = {
     "error|indoor-coil-temperature-sensor-failed": BinarySensorEntityDescription(
         key="error|indoor-coil-temperature-sensor-failed",
         name="Water Tray Full",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # Security System
+    "tampered": BinarySensorEntityDescription(
+        key="tampered",
+        name="Tampered",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    "triggered": BinarySensorEntityDescription(
+        key="triggered",
+        name="Triggered",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 }

--- a/custom_components/hubspace/manifest.json
+++ b/custom_components/hubspace/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jdeath/Hubspace-Homeassistant/issues",
   "loggers": ["aioafero"],
-  "requirements": ["aioafero==4.1.0", "aiofiles"],
+  "requirements": ["aioafero==4.1.1", "aiofiles"],
   "version": "5.4.0"
 }

--- a/custom_components/hubspace/manifest.json
+++ b/custom_components/hubspace/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jdeath/Hubspace-Homeassistant/issues",
   "loggers": ["aioafero"],
-  "requirements": ["aioafero==4.0.0", "aiofiles"],
+  "requirements": ["aioafero==4.1.0", "aiofiles"],
   "version": "5.4.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Hubspace-Homeassistant",
   "render_readme": true,
-  "homeassistant": "2024.8"
+  "homeassistant": "2024.12"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 homeassistant
-aioafero>=4
+aioafero>=4.1.0
 aiofiles>=24.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 homeassistant
-aioafero>=4.1.0
+aioafero>=4.1.1
 aiofiles>=24.1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import contextlib
 import datetime
 import logging
 
-from aioafero import v1
+from aioafero import AferoDevice, v1
 from aioafero.v1.auth import token_data
 from aioafero.v1.controllers.event import EventType
 from homeassistant.const import CONF_PASSWORD, CONF_TIMEOUT, CONF_TOKEN, CONF_USERNAME
@@ -19,6 +19,8 @@ from custom_components.hubspace.const import (
     VERSION_MAJOR,
     VERSION_MINOR,
 )
+
+from .utils import hs_raw_from_device
 
 
 @pytest.fixture(autouse=True)
@@ -58,12 +60,26 @@ async def mocked_bridge(mocker) -> v1.AferoBridgeV1:
 
     # Enable ad-hoc polls
     async def generate_events_from_data(data):
-        task = asyncio.create_task(hs_bridge.events.generate_events_from_data(data))
-        await task
+        raw_data = await hs_bridge.events.generate_events_from_data(data)
+        mocker.patch(
+            "aioafero.v1.controllers.event.EventStream.gather_data",
+            return_value=raw_data,
+        )
+        await hs_bridge.async_block_until_done()
+
+    # Fake a poll for discovery
+    async def generate_devices_from_data(devices: list[AferoDevice]):
+        raw_data = [hs_raw_from_device(device) for device in devices]
+        mocker.patch(
+            "aioafero.v1.controllers.event.EventStream.gather_data",
+            return_value=raw_data,
+        )
+        await hs_bridge.events.generate_events_from_data(raw_data)
         await hs_bridge.async_block_until_done()
 
     hs_bridge.emit_event = emit_event
     hs_bridge.generate_events_from_data = generate_events_from_data
+    hs_bridge.generate_devices_from_data = generate_devices_from_data
     # Override context manager
     hs_bridge.__aenter__ = mocker.AsyncMock(return_value=hs_bridge)
     hs_bridge.__aexit__ = mocker.AsyncMock()

--- a/tests/device_dumps/security-system.json
+++ b/tests/device_dumps/security-system.json
@@ -1,0 +1,6446 @@
+[
+  {
+    "id": "1f31be19-b9b9-4ca8-8a22-20d0015ec2dd",
+    "device_id": "ce68c348-cd68-4ce3-937d-bf18619ae970",
+    "model": "Security System Keypad",
+    "device_class": "security-system-keypad",
+    "default_name": "Security System Keypad",
+    "default_image": "security-system-keypad-icon",
+    "friendly_name": "Main Keypad",
+    "functions": [
+      {
+        "id": "de45b65f-0c63-452c-a514-203002239ff6",
+        "createdTimestampMs": 1718063128251,
+        "updatedTimestampMs": 1718063128251,
+        "functionClass": "volume",
+        "functionInstance": "buzzer-volume",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "53f006a3-38e5-4943-be8c-c75743d1a053",
+            "createdTimestampMs": 1718063128305,
+            "updatedTimestampMs": 1718063128305,
+            "name": "volume-01",
+            "deviceValues": [
+              {
+                "id": "7ad29738-8208-4d00-83ca-96290f348e1b",
+                "createdTimestampMs": 1718063128321,
+                "updatedTimestampMs": 1718063128321,
+                "type": "attribute",
+                "key": "1",
+                "value": "5"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "56a722a1-f3c6-4596-a07b-95e4622631f0",
+            "createdTimestampMs": 1718063128268,
+            "updatedTimestampMs": 1718063128268,
+            "name": "volume-00",
+            "deviceValues": [
+              {
+                "id": "164e889c-4860-490d-8e81-9776a99b3814",
+                "createdTimestampMs": 1718063128293,
+                "updatedTimestampMs": 1718063128293,
+                "type": "attribute",
+                "key": "1",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "ea5eb166-89a7-49a7-b95f-8a5c3ab01de1",
+            "createdTimestampMs": 1718063128383,
+            "updatedTimestampMs": 1718063128383,
+            "name": "volume-04",
+            "deviceValues": [
+              {
+                "id": "120b1e88-7ff6-464c-9ef2-4b5782edfd92",
+                "createdTimestampMs": 1718063128398,
+                "updatedTimestampMs": 1718063128398,
+                "type": "attribute",
+                "key": "1",
+                "value": "100"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "4fd84ba0-aede-41e8-aefd-efc266344965",
+            "createdTimestampMs": 1718063128331,
+            "updatedTimestampMs": 1718063128331,
+            "name": "volume-02",
+            "deviceValues": [
+              {
+                "id": "f7a5e77a-5187-4797-b1cb-0a879cadaced",
+                "createdTimestampMs": 1718063128346,
+                "updatedTimestampMs": 1718063128346,
+                "type": "attribute",
+                "key": "1",
+                "value": "30"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "2f5687d0-411a-4db4-a86f-4981432f7eea",
+            "createdTimestampMs": 1718063128357,
+            "updatedTimestampMs": 1718063128357,
+            "name": "volume-03",
+            "deviceValues": [
+              {
+                "id": "2806f57c-557b-443d-b2da-777953217a2c",
+                "createdTimestampMs": 1718063128372,
+                "updatedTimestampMs": 1718063128372,
+                "type": "attribute",
+                "key": "1",
+                "value": "60"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "cc40cdd4-1429-401e-b26c-fcd07550e74c",
+        "createdTimestampMs": 1718063128456,
+        "updatedTimestampMs": 1718063128456,
+        "functionClass": "tamper-detection",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "8098cfe9-b674-44d3-aaf9-c47a5f83586e",
+            "createdTimestampMs": 1718063128498,
+            "updatedTimestampMs": 1718063128498,
+            "name": "tampered",
+            "deviceValues": [
+              {
+                "id": "65e88081-0a6f-4063-b583-b38f8544306e",
+                "createdTimestampMs": 1718063128513,
+                "updatedTimestampMs": 1718063128513,
+                "type": "attribute",
+                "key": "400",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "a278dc84-c6f2-4b5e-a2d6-5f547bae1fed",
+            "createdTimestampMs": 1718063128472,
+            "updatedTimestampMs": 1718063128472,
+            "name": "not-tampered",
+            "deviceValues": [
+              {
+                "id": "09e40370-585b-4cb3-a679-d2e5814c5697",
+                "createdTimestampMs": 1718063128487,
+                "updatedTimestampMs": 1718063128487,
+                "type": "attribute",
+                "key": "400",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "c84eb8ff-33e4-4367-be10-50755a90d85a",
+        "createdTimestampMs": 1718063128523,
+        "updatedTimestampMs": 1718063128523,
+        "functionClass": "battery-level",
+        "type": "numeric",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "055f47ab-8a4f-447c-829e-459d70230d6e",
+            "createdTimestampMs": 1718063128538,
+            "updatedTimestampMs": 1718063128538,
+            "name": "battery-level",
+            "deviceValues": [
+              {
+                "id": "bbe39032-80bf-4363-9151-d8b8d80a8b10",
+                "createdTimestampMs": 1718063128554,
+                "updatedTimestampMs": 1718063128554,
+                "type": "attribute",
+                "key": "65079"
+              }
+            ],
+            "range": {
+              "min": 0,
+              "max": 100,
+              "step": 1
+            }
+          }
+        ]
+      },
+      {
+        "id": "21cff216-f367-4018-a4ec-dd1faa164144",
+        "createdTimestampMs": 1718063128409,
+        "updatedTimestampMs": 1718063128409,
+        "functionClass": "siren-device-id",
+        "type": "string",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "9b2be260-5c75-4514-b602-00f0a98a7fc0",
+            "createdTimestampMs": 1718063128423,
+            "updatedTimestampMs": 1718063128423,
+            "name": "siren-device-id",
+            "deviceValues": [
+              {
+                "id": "0265dea7-4015-40c1-9f4b-7d93409e1da9",
+                "createdTimestampMs": 1718063128446,
+                "updatedTimestampMs": 1718063128446,
+                "type": "attribute",
+                "key": "200",
+                "format": "string"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      }
+    ],
+    "states": [
+      {
+        "functionClass": "volume",
+        "value": "volume-02",
+        "lastUpdateTime": 0,
+        "functionInstance": "buzzer-volume"
+      },
+      {
+        "functionClass": "tamper-detection",
+        "value": "not-tampered",
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "battery-level",
+        "value": 90,
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "siren-device-id",
+        "value": "8972c4d8d55c0726",
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "wifi-mac-address",
+        "value": "2d296d03-05ad-4dcb-95d3-6e06cc60d521",
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "geo-coordinates",
+        "value": {
+          "geo-coordinates": {
+            "latitude": "0",
+            "longitude": "0"
+          }
+        },
+        "lastUpdateTime": 0,
+        "functionInstance": "system-device-location"
+      },
+      {
+        "functionClass": "scheduler-flags",
+        "value": 0,
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "available",
+        "value": true,
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "visible",
+        "value": true,
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "direct",
+        "value": false,
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "ble-mac-address",
+        "value": "e8973a0a-a6a3-42e0-8d60-ac593e205da5",
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      }
+    ],
+    "children": [],
+    "manufacturerName": "DEFIANT"
+  },
+  {
+    "id": "7f4e4c01-e799-45c5-9b1a-385433a78edc",
+    "device_id": "3cf4a43a-f2b4-4c63-a324-038c94962813",
+    "model": "Security System",
+    "device_class": "security-system",
+    "default_name": "Security System",
+    "default_image": "leedarson-security-system-icon",
+    "friendly_name": "Helms Deep",
+    "functions": [
+      {
+        "id": "6e5f2ece-1432-40d9-8904-f91b18674ef4",
+        "createdTimestampMs": 1737748110225,
+        "updatedTimestampMs": 1743797379402,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-18",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "48a3d1d5-691e-4084-a6fd-e50b8478bad7",
+            "createdTimestampMs": 1737748110236,
+            "updatedTimestampMs": 1743797379410,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "e57610af-ad54-4208-bd6b-111ef6abaf5c",
+                "createdTimestampMs": 1737748110246,
+                "updatedTimestampMs": 1743797379419,
+                "type": "attribute",
+                "key": "318",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "df2535a2-1a59-4e7f-a30e-a25220be9faa",
+        "createdTimestampMs": 1737748109400,
+        "updatedTimestampMs": 1743797378679,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-19",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "11d24946-845b-4e7f-bc26-a42d73fb7e68",
+            "createdTimestampMs": 1737748109409,
+            "updatedTimestampMs": 1743797378688,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "cc6f08a8-3407-4dd0-a6ea-fd058b25e401",
+                "createdTimestampMs": 1737748109418,
+                "updatedTimestampMs": 1743797378697,
+                "type": "attribute",
+                "key": "219",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "8088a48d-f3bb-44f2-b6b1-bfc0ec3b9885",
+        "createdTimestampMs": 1737748109215,
+        "updatedTimestampMs": 1743797382215,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-12",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "7ac3e1da-584e-40b7-8672-c71a4b651efe",
+            "createdTimestampMs": 1737748109224,
+            "updatedTimestampMs": 1743797382224,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "73f9492a-72b6-439b-b7ba-fd93d41b820d",
+                "createdTimestampMs": 1737748109235,
+                "updatedTimestampMs": 1743797382232,
+                "type": "attribute",
+                "key": "212",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "332b3b8e-66b8-4a7c-af34-3e93d7c77517",
+        "createdTimestampMs": 1737748107010,
+        "updatedTimestampMs": 1743797377997,
+        "functionClass": "song-id",
+        "functionInstance": "alarm",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "a89fd907-8c05-4901-bb27-831538d59d74",
+            "createdTimestampMs": 1737748107258,
+            "updatedTimestampMs": 1743797378113,
+            "name": "preset-13",
+            "deviceValues": [
+              {
+                "id": "74a7c91f-199d-4a75-a9ce-78d1bc93e054",
+                "createdTimestampMs": 1737748107268,
+                "updatedTimestampMs": 1743797378122,
+                "type": "attribute",
+                "key": "25",
+                "value": "715"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "925af776-a643-4d98-bcbc-9efb61346899",
+            "createdTimestampMs": 1737748107038,
+            "updatedTimestampMs": 1743797378182,
+            "name": "preset-02",
+            "deviceValues": [
+              {
+                "id": "0848dc44-67c9-4943-af47-e5d027e7a9b2",
+                "createdTimestampMs": 1737748107049,
+                "updatedTimestampMs": 1743797378193,
+                "type": "attribute",
+                "key": "25",
+                "value": "704"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "a48f3140-0df5-4acf-af07-3f312606de56",
+            "createdTimestampMs": 1737748107242,
+            "updatedTimestampMs": 1743797378037,
+            "name": "preset-12",
+            "deviceValues": [
+              {
+                "id": "ae6cbb32-cce1-48ca-aac6-a6856e3b22c9",
+                "createdTimestampMs": 1737748107251,
+                "updatedTimestampMs": 1743797378045,
+                "type": "attribute",
+                "key": "25",
+                "value": "714"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "e88984b0-1e0e-47c1-9a6a-f2e2a7073379",
+            "createdTimestampMs": 1737748107021,
+            "updatedTimestampMs": 1743797378021,
+            "name": "preset-01",
+            "deviceValues": [
+              {
+                "id": "5b780309-5fe8-4306-8495-45e788ffea1e",
+                "createdTimestampMs": 1737748107031,
+                "updatedTimestampMs": 1743797378031,
+                "type": "attribute",
+                "key": "25",
+                "value": "703"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "75b49aee-086b-47d2-9a50-0b490b178754",
+            "createdTimestampMs": 1737748107136,
+            "updatedTimestampMs": 1743797378066,
+            "name": "preset-07",
+            "deviceValues": [
+              {
+                "id": "07daf008-b76f-4b4b-8194-0b5615473150",
+                "createdTimestampMs": 1737748107149,
+                "updatedTimestampMs": 1743797378075,
+                "type": "attribute",
+                "key": "25",
+                "value": "709"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "32f6961f-bf0a-4440-a093-c5ac4e2a5b40",
+            "createdTimestampMs": 1737748107112,
+            "updatedTimestampMs": 1743797378006,
+            "name": "preset-06",
+            "deviceValues": [
+              {
+                "id": "53a22f81-7380-4d40-b9ad-fd5192097438",
+                "createdTimestampMs": 1737748107121,
+                "updatedTimestampMs": 1743797378015,
+                "type": "attribute",
+                "key": "25",
+                "value": "708"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "a0262372-6bdb-4d14-88fa-2883dbac9ae4",
+            "createdTimestampMs": 1737748107093,
+            "updatedTimestampMs": 1743797378051,
+            "name": "preset-05",
+            "deviceValues": [
+              {
+                "id": "14ea62b1-2625-4557-b085-9279d918fd39",
+                "createdTimestampMs": 1737748107105,
+                "updatedTimestampMs": 1743797378060,
+                "type": "attribute",
+                "key": "25",
+                "value": "707"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "9161012f-ffa1-463b-979e-8ac86e166533",
+            "createdTimestampMs": 1737748107188,
+            "updatedTimestampMs": 1743797378143,
+            "name": "preset-09",
+            "deviceValues": [
+              {
+                "id": "7cfe8e71-bf36-4fc6-8972-d06b494f6b0e",
+                "createdTimestampMs": 1737748107198,
+                "updatedTimestampMs": 1743797378153,
+                "type": "attribute",
+                "key": "25",
+                "value": "711"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "9487c1a1-e46d-4cf9-acb7-e6e75b2ec7ec",
+            "createdTimestampMs": 1737748107205,
+            "updatedTimestampMs": 1743797378167,
+            "name": "preset-10",
+            "deviceValues": [
+              {
+                "id": "d99faa69-d61c-4ffe-b6f7-55c6b918c6b7",
+                "createdTimestampMs": 1737748107215,
+                "updatedTimestampMs": 1743797378176,
+                "type": "attribute",
+                "key": "25",
+                "value": "712"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "5aedfc8d-2e16-4406-b2a3-3694930fcfb6",
+            "createdTimestampMs": 1737748107056,
+            "updatedTimestampMs": 1743797378200,
+            "name": "preset-03",
+            "deviceValues": [
+              {
+                "id": "f84c8e83-f053-4cfe-91c2-aff94f0a8b9d",
+                "createdTimestampMs": 1737748107066,
+                "updatedTimestampMs": 1743797378209,
+                "type": "attribute",
+                "key": "25",
+                "value": "705"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "5cb779d8-4df1-4504-937a-39f8da2485f5",
+            "createdTimestampMs": 1737748107223,
+            "updatedTimestampMs": 1743797378082,
+            "name": "preset-11",
+            "deviceValues": [
+              {
+                "id": "6c932537-1e49-411c-80d1-6de5e1dd8be6",
+                "createdTimestampMs": 1737748107234,
+                "updatedTimestampMs": 1743797378091,
+                "type": "attribute",
+                "key": "25",
+                "value": "713"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "dfcfe408-14cb-4177-a88d-17509fc4eae0",
+            "createdTimestampMs": 1737748107073,
+            "updatedTimestampMs": 1743797378098,
+            "name": "preset-04",
+            "deviceValues": [
+              {
+                "id": "ee2a9292-c59c-4d7a-8557-31336a43b0ce",
+                "createdTimestampMs": 1737748107083,
+                "updatedTimestampMs": 1743797378106,
+                "type": "attribute",
+                "key": "25",
+                "value": "706"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "884d2e22-cce9-4ce6-a293-1c41a2d0fb17",
+            "createdTimestampMs": 1737748107168,
+            "updatedTimestampMs": 1743797378128,
+            "name": "preset-08",
+            "deviceValues": [
+              {
+                "id": "9f5c11bc-6f6c-480d-bc47-610e23539e57",
+                "createdTimestampMs": 1737748107181,
+                "updatedTimestampMs": 1743797378137,
+                "type": "attribute",
+                "key": "25",
+                "value": "710"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "5e831b25-24a2-48dc-9d2b-e6a778a220e0",
+        "createdTimestampMs": 1737748111141,
+        "updatedTimestampMs": 1743797377370,
+        "functionClass": "keyfob-used",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "d58752d8-74df-4bef-b4d4-61fab26cd406",
+            "createdTimestampMs": 1737748111202,
+            "updatedTimestampMs": 1743797377556,
+            "name": "keyfob-4",
+            "deviceValues": [
+              {
+                "id": "6f0d73a2-e69c-4e8e-8319-9e015d93f310",
+                "createdTimestampMs": 1737748111212,
+                "updatedTimestampMs": 1743797377565,
+                "type": "attribute",
+                "key": "403",
+                "value": "4"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "455460d7-4a2f-4dc2-92ac-6af3a07b132d",
+            "createdTimestampMs": 1737748111253,
+            "updatedTimestampMs": 1743797377539,
+            "name": "keyfob-7",
+            "deviceValues": [
+              {
+                "id": "867a1263-6c17-4ce2-8dae-81b1e1d6dff3",
+                "createdTimestampMs": 1737748111263,
+                "updatedTimestampMs": 1743797377549,
+                "type": "attribute",
+                "key": "403",
+                "value": "7"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "11636cbf-decd-49a9-a788-105296636499",
+            "createdTimestampMs": 1737748111151,
+            "updatedTimestampMs": 1743797377487,
+            "name": "keyfob-1",
+            "deviceValues": [
+              {
+                "id": "23d43e97-a4ce-45bb-b469-bb910ce3ef6f",
+                "createdTimestampMs": 1737748111161,
+                "updatedTimestampMs": 1743797377496,
+                "type": "attribute",
+                "key": "403",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "9218bb93-7979-4936-bc3d-9369ac4ef650",
+            "createdTimestampMs": 1737748111270,
+            "updatedTimestampMs": 1743797377473,
+            "name": "keyfob-8",
+            "deviceValues": [
+              {
+                "id": "aadac512-418c-4d17-b8bc-be661996d75d",
+                "createdTimestampMs": 1737748111280,
+                "updatedTimestampMs": 1743797377481,
+                "type": "attribute",
+                "key": "403",
+                "value": "8"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "9862d8c1-f0b8-4124-aca5-b474cb990d22",
+            "createdTimestampMs": 1737748111304,
+            "updatedTimestampMs": 1743797377458,
+            "name": "keyfob-10",
+            "deviceValues": [
+              {
+                "id": "b60739a4-9655-4d1a-be5d-171d5bcf3b50",
+                "createdTimestampMs": 1737748111314,
+                "updatedTimestampMs": 1743797377466,
+                "type": "attribute",
+                "key": "403",
+                "value": "10"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "a1176c24-a279-41e6-9533-8fc24322cc0f",
+            "createdTimestampMs": 1737748111287,
+            "updatedTimestampMs": 1743797377443,
+            "name": "keyfob-9",
+            "deviceValues": [
+              {
+                "id": "aedb6e3c-0201-49bd-a486-2390d15cc8b4",
+                "createdTimestampMs": 1737748111297,
+                "updatedTimestampMs": 1743797377452,
+                "type": "attribute",
+                "key": "403",
+                "value": "9"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "81bc0dca-3d2b-49a7-8934-0608ef8b89dc",
+            "createdTimestampMs": 1737748111185,
+            "updatedTimestampMs": 1743797377390,
+            "name": "keyfob-3",
+            "deviceValues": [
+              {
+                "id": "de514296-0ef1-4585-bfc1-928d24d59bd5",
+                "createdTimestampMs": 1737748111196,
+                "updatedTimestampMs": 1743797377411,
+                "type": "attribute",
+                "key": "403",
+                "value": "3"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "cb5405dc-3d33-4402-b3f7-0c55b779f1fe",
+            "createdTimestampMs": 1737748111168,
+            "updatedTimestampMs": 1743797377522,
+            "name": "keyfob-2",
+            "deviceValues": [
+              {
+                "id": "09706057-1c59-4e24-9be3-23b9e0283b60",
+                "createdTimestampMs": 1737748111178,
+                "updatedTimestampMs": 1743797377532,
+                "type": "attribute",
+                "key": "403",
+                "value": "2"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "6fcc3bf0-43dd-4644-971a-3a0d3ed06c96",
+            "createdTimestampMs": 1737748111219,
+            "updatedTimestampMs": 1743797377504,
+            "name": "keyfob-5",
+            "deviceValues": [
+              {
+                "id": "5347cfc8-3819-4c84-bd42-9823aa126e9a",
+                "createdTimestampMs": 1737748111229,
+                "updatedTimestampMs": 1743797377515,
+                "type": "attribute",
+                "key": "403",
+                "value": "5"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "113404fa-8903-4699-a4bf-892daee7fecc",
+            "createdTimestampMs": 1737748111236,
+            "updatedTimestampMs": 1743797377426,
+            "name": "keyfob-6",
+            "deviceValues": [
+              {
+                "id": "54c57953-eddf-40f8-8bd9-b9d84aca5f4e",
+                "createdTimestampMs": 1737748111246,
+                "updatedTimestampMs": 1743797377436,
+                "type": "attribute",
+                "key": "403",
+                "value": "6"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "44743ed8-71a5-4870-8687-f15f41ba0968",
+        "createdTimestampMs": 1737748107922,
+        "updatedTimestampMs": 1743797380803,
+        "functionClass": "pin",
+        "functionInstance": "pin-7",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "be8a198d-e92d-4ef6-8e85-35529a64e0c5",
+            "createdTimestampMs": 1737748107931,
+            "updatedTimestampMs": 1743797380812,
+            "name": "pin-7",
+            "deviceValues": [
+              {
+                "id": "065011dc-3360-4bdf-bf55-e4a3aa5254dc",
+                "createdTimestampMs": 1737748107941,
+                "updatedTimestampMs": 1743797380823,
+                "type": "attribute",
+                "key": "107",
+                "format": "lock-pin"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "340446fa-653e-45a1-9e7f-d56e56c67e6f",
+        "createdTimestampMs": 1737748108539,
+        "updatedTimestampMs": 1743797377679,
+        "functionClass": "keyfob-config",
+        "functionInstance": "keyfob-5",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "64879348-14b3-4946-b5e3-576644998f57",
+            "createdTimestampMs": 1737748108582,
+            "updatedTimestampMs": 1743797377704,
+            "name": "delete",
+            "deviceValues": [
+              {
+                "id": "1cdc0455-db74-4937-aead-6543ec941c96",
+                "createdTimestampMs": 1737748108591,
+                "updatedTimestampMs": 1743797377713,
+                "type": "attribute",
+                "key": "165",
+                "value": "2"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "3fda8902-3460-470a-96ec-aa7ada9b58d5",
+            "createdTimestampMs": 1737748108549,
+            "updatedTimestampMs": 1743797377719,
+            "name": "disabled",
+            "deviceValues": [
+              {
+                "id": "4b90d3ba-2c9d-43fa-b11a-1e8242d94bdd",
+                "createdTimestampMs": 1737748108559,
+                "updatedTimestampMs": 1743797377728,
+                "type": "attribute",
+                "key": "165",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "e2abd550-4c6c-4eee-ae0e-7b512a3473bb",
+            "createdTimestampMs": 1737748108565,
+            "updatedTimestampMs": 1743797377689,
+            "name": "enabled",
+            "deviceValues": [
+              {
+                "id": "3f4c3767-571f-4d14-a81b-b0bcccefa9e8",
+                "createdTimestampMs": 1737748108575,
+                "updatedTimestampMs": 1743797377698,
+                "type": "attribute",
+                "key": "165",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "a682cf3e-4bc3-496e-af0d-389935739e20",
+        "createdTimestampMs": 1737748106548,
+        "updatedTimestampMs": 1743797378906,
+        "functionClass": "volume",
+        "functionInstance": "exit-delay-stay",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "ffbb703c-910c-4f2a-9ddc-8c262c576a95",
+            "createdTimestampMs": 1737748106587,
+            "updatedTimestampMs": 1743797379003,
+            "name": "volume-01",
+            "deviceValues": [
+              {
+                "id": "b8d0d9e0-aecf-47f5-b0ce-01cec1d0d34f",
+                "createdTimestampMs": 1737748106597,
+                "updatedTimestampMs": 1743797379027,
+                "type": "attribute",
+                "key": "20",
+                "value": "6"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "2c78986f-d7df-4e30-bc2e-926baad6d854",
+            "createdTimestampMs": 1737748106621,
+            "updatedTimestampMs": 1743797378920,
+            "name": "volume-03",
+            "deviceValues": [
+              {
+                "id": "b803c146-c1cc-4d52-a7fc-e414e0b1d0f1",
+                "createdTimestampMs": 1737748106631,
+                "updatedTimestampMs": 1743797378954,
+                "type": "attribute",
+                "key": "20",
+                "value": "15"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "6933d6a5-922b-4eca-87d8-b070dcc4932c",
+            "createdTimestampMs": 1737748106569,
+            "updatedTimestampMs": 1743797379076,
+            "name": "volume-00",
+            "deviceValues": [
+              {
+                "id": "ca10bba8-8597-4838-af45-3ea6b814c761",
+                "createdTimestampMs": 1737748106579,
+                "updatedTimestampMs": 1743797379089,
+                "type": "attribute",
+                "key": "20",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "ba0b59ef-17ad-4c24-9d17-05ff75c5d31f",
+            "createdTimestampMs": 1737748106637,
+            "updatedTimestampMs": 1743797378965,
+            "name": "volume-04",
+            "deviceValues": [
+              {
+                "id": "4cbf4da8-76b7-4233-a732-9533c32d6722",
+                "createdTimestampMs": 1737748106648,
+                "updatedTimestampMs": 1743797378986,
+                "type": "attribute",
+                "key": "20",
+                "value": "30"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "dd56c6cb-cc54-4909-9ac9-a37bc2ff7b4e",
+            "createdTimestampMs": 1737748106604,
+            "updatedTimestampMs": 1743797379046,
+            "name": "volume-02",
+            "deviceValues": [
+              {
+                "id": "38d40b9b-0ade-4de8-b23d-15f6559abc6b",
+                "createdTimestampMs": 1737748106614,
+                "updatedTimestampMs": 1743797379067,
+                "type": "attribute",
+                "key": "20",
+                "value": "10"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "4d06c17e-200d-41b5-94e4-5036552be2eb",
+        "createdTimestampMs": 1737748109582,
+        "updatedTimestampMs": 1743797377808,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-26",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "c0ab02e8-8e80-430d-946b-b6270a3db802",
+            "createdTimestampMs": 1737748109591,
+            "updatedTimestampMs": 1743797377816,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "f9e0d1b4-b7d9-43cb-a5e0-c49ee529c876",
+                "createdTimestampMs": 1737748109601,
+                "updatedTimestampMs": 1743797377824,
+                "type": "attribute",
+                "key": "226",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "9053261e-a96d-4f33-93cb-a376e04fd714",
+        "createdTimestampMs": 1737748110117,
+        "updatedTimestampMs": 1743797379870,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-14",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "a8f86551-d321-42b3-9256-24d5f0bd3e28",
+            "createdTimestampMs": 1737748110127,
+            "updatedTimestampMs": 1743797379880,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "e9eb6e32-bde0-4192-98e6-19ea928e3d7e",
+                "createdTimestampMs": 1737748110136,
+                "updatedTimestampMs": 1743797379890,
+                "type": "attribute",
+                "key": "314",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "61dd06d2-d689-497b-ae28-6c0732428da9",
+        "createdTimestampMs": 1737748110065,
+        "updatedTimestampMs": 1743797382015,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-12",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "fcdf473e-07c3-4c6e-83f7-84a6a5602058",
+            "createdTimestampMs": 1737748110075,
+            "updatedTimestampMs": 1743797382023,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "8176cab5-55d4-4a96-a3ce-9a068f1d94bd",
+                "createdTimestampMs": 1737748110085,
+                "updatedTimestampMs": 1743797382031,
+                "type": "attribute",
+                "key": "312",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "ec03c0df-d47c-4951-a21b-8168e7e3b6ec",
+        "createdTimestampMs": 1737748109160,
+        "updatedTimestampMs": 1743797382506,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-10",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "4bfa7dad-f9ca-49dc-844b-57336945a314",
+            "createdTimestampMs": 1737748109170,
+            "updatedTimestampMs": 1743797382514,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "7cab51da-a608-480e-b455-cc2e028ec099",
+                "createdTimestampMs": 1737748109180,
+                "updatedTimestampMs": 1743797382522,
+                "type": "attribute",
+                "key": "210",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "2f82ec38-fd4c-49b0-9c4e-a89fae164881",
+        "createdTimestampMs": 1737748109927,
+        "updatedTimestampMs": 1743797380253,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-7",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "69dfe3bd-7d6c-4245-b45b-8e94eb68990c",
+            "createdTimestampMs": 1737748109937,
+            "updatedTimestampMs": 1743797380263,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "be1b6012-751c-4288-bb66-ef5e9b9628d2",
+                "createdTimestampMs": 1737748109946,
+                "updatedTimestampMs": 1743797380271,
+                "type": "attribute",
+                "key": "307",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "523a0223-e6b9-4cee-a866-28e14d601728",
+        "createdTimestampMs": 1737748110196,
+        "updatedTimestampMs": 1743797379678,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-17",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "a2bb4e3e-ece8-4975-912c-7350fc0283d6",
+            "createdTimestampMs": 1737748110207,
+            "updatedTimestampMs": 1743797379687,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "c3a38619-16a1-457b-bbfb-b5e4591d23d3",
+                "createdTimestampMs": 1737748110218,
+                "updatedTimestampMs": 1743797379696,
+                "type": "attribute",
+                "key": "317",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "78de50c8-2191-477b-88a7-51716c315045",
+        "createdTimestampMs": 1737748109793,
+        "updatedTimestampMs": 1743797379155,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-2",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "beff64e8-5484-4a49-b377-fde4aa130b69",
+            "createdTimestampMs": 1737748109803,
+            "updatedTimestampMs": 1743797379166,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "fb17b235-14ac-4fe9-8268-05887342d359",
+                "createdTimestampMs": 1737748109812,
+                "updatedTimestampMs": 1743797379182,
+                "type": "attribute",
+                "key": "302",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "b6d0c39f-f53a-420a-9c89-8a4e5327c93e",
+        "createdTimestampMs": 1737748110010,
+        "updatedTimestampMs": 1743797379755,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-10",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "4b38cd5f-3363-4793-80ef-1f3d9b3535e0",
+            "createdTimestampMs": 1737748110021,
+            "updatedTimestampMs": 1743797379764,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "e975592f-b7cc-44b4-87e8-a3c09bc79985",
+                "createdTimestampMs": 1737748110031,
+                "updatedTimestampMs": 1743797379774,
+                "type": "attribute",
+                "key": "310",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "ec44acb6-014d-4500-9a15-f1764964a321",
+        "createdTimestampMs": 1737748107869,
+        "updatedTimestampMs": 1743797382437,
+        "functionClass": "pin",
+        "functionInstance": "pin-5",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "5daf7de1-3b10-4449-b4fb-ff413170e2db",
+            "createdTimestampMs": 1737748107878,
+            "updatedTimestampMs": 1743797382445,
+            "name": "pin-5",
+            "deviceValues": [
+              {
+                "id": "3e251aa8-e873-4be7-9239-e0948de6375c",
+                "createdTimestampMs": 1737748107888,
+                "updatedTimestampMs": 1743797382454,
+                "type": "attribute",
+                "key": "105",
+                "format": "lock-pin"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "dfe8d60a-b6a8-4aa8-badf-7e0cce2beb5d",
+        "createdTimestampMs": 1737748107948,
+        "updatedTimestampMs": 1743797378216,
+        "functionClass": "pin",
+        "functionInstance": "pin-8",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "1eff2f60-9060-426a-8829-4f15bfd16b58",
+            "createdTimestampMs": 1737748107958,
+            "updatedTimestampMs": 1743797378224,
+            "name": "pin-8",
+            "deviceValues": [
+              {
+                "id": "8b682256-bf92-47ff-82f0-6b27bc8811fd",
+                "createdTimestampMs": 1737748107968,
+                "updatedTimestampMs": 1743797378233,
+                "type": "attribute",
+                "key": "108",
+                "format": "lock-pin"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "bf99f064-4874-428a-9d59-bf2757263e76",
+        "createdTimestampMs": 1737748107895,
+        "updatedTimestampMs": 1743797382107,
+        "functionClass": "pin",
+        "functionInstance": "pin-6",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "cffbb91a-0dd2-4d1a-9e26-8d047280c822",
+            "createdTimestampMs": 1737748107905,
+            "updatedTimestampMs": 1743797382116,
+            "name": "pin-6",
+            "deviceValues": [
+              {
+                "id": "a6f30300-428b-4f50-a114-c8b8c150bcd3",
+                "createdTimestampMs": 1737748107915,
+                "updatedTimestampMs": 1743797382124,
+                "type": "attribute",
+                "key": "106",
+                "format": "lock-pin"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "7996ed5e-e6df-4a5f-ba87-6ec6cbaa9a5d",
+        "createdTimestampMs": 1737748110469,
+        "updatedTimestampMs": 1743797379189,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-27",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "420885a0-95c0-4dba-a10c-0c0a43dd3c0e",
+            "createdTimestampMs": 1737748110479,
+            "updatedTimestampMs": 1743797379199,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "8dbe17c2-6ecc-44af-9929-4b202002b389",
+                "createdTimestampMs": 1737748110488,
+                "updatedTimestampMs": 1743797379212,
+                "type": "attribute",
+                "key": "327",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "a1b1248f-adf2-4731-adf5-ee83aec0e816",
+        "createdTimestampMs": 1737748110414,
+        "updatedTimestampMs": 1743797381403,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-25",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "2406fecd-ff47-481b-ae5a-0e2f3823259c",
+            "createdTimestampMs": 1737748110425,
+            "updatedTimestampMs": 1743797381413,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "ccbd03b2-2773-422c-84e7-451526916071",
+                "createdTimestampMs": 1737748110435,
+                "updatedTimestampMs": 1743797381422,
+                "type": "attribute",
+                "key": "325",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "0cdb867b-7913-43ab-a661-dfd11b812d44",
+        "createdTimestampMs": 1737748108419,
+        "updatedTimestampMs": 1743797380644,
+        "functionClass": "keyfob-config",
+        "functionInstance": "keyfob-3",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "b3ec0b46-324d-4281-bf54-60e3e2244ca8",
+            "createdTimestampMs": 1737748108463,
+            "updatedTimestampMs": 1743797380692,
+            "name": "delete",
+            "deviceValues": [
+              {
+                "id": "cec02e26-946b-4098-96eb-10c067c648e3",
+                "createdTimestampMs": 1737748108472,
+                "updatedTimestampMs": 1743797380709,
+                "type": "attribute",
+                "key": "163",
+                "value": "2"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "e49b23cb-3325-4008-830b-4f0a23955ec1",
+            "createdTimestampMs": 1737748108429,
+            "updatedTimestampMs": 1743797380674,
+            "name": "disabled",
+            "deviceValues": [
+              {
+                "id": "801ae852-8289-4aa2-ac10-979ba6114c42",
+                "createdTimestampMs": 1737748108439,
+                "updatedTimestampMs": 1743797380685,
+                "type": "attribute",
+                "key": "163",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "411ee482-7000-42f7-ad4f-79b23c784f4e",
+            "createdTimestampMs": 1737748108446,
+            "updatedTimestampMs": 1743797380654,
+            "name": "enabled",
+            "deviceValues": [
+              {
+                "id": "5df94e10-2a8d-48b3-9510-03d070bf5d5d",
+                "createdTimestampMs": 1737748108456,
+                "updatedTimestampMs": 1743797380667,
+                "type": "attribute",
+                "key": "163",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "49bb5cf2-e7f5-4b9e-aa0e-c2e7ccb7a4e0",
+        "createdTimestampMs": 1737748107527,
+        "updatedTimestampMs": 1743797381630,
+        "functionClass": "song-id",
+        "functionInstance": "beep",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "58948989-d923-4d08-af45-6bf262cd64ba",
+            "createdTimestampMs": 1737748107554,
+            "updatedTimestampMs": 1743797381811,
+            "name": "preset-02",
+            "deviceValues": [
+              {
+                "id": "165ed1d3-218f-4a0d-87d5-9cdf4cb91f66",
+                "createdTimestampMs": 1737748107565,
+                "updatedTimestampMs": 1743797381820,
+                "type": "attribute",
+                "key": "27",
+                "value": "704"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "f13f0ca3-19f7-45ae-b64e-77a15adc4d12",
+            "createdTimestampMs": 1737748107674,
+            "updatedTimestampMs": 1743797381640,
+            "name": "preset-09",
+            "deviceValues": [
+              {
+                "id": "dc9ec72c-84dc-4404-ad21-e55cac062bc4",
+                "createdTimestampMs": 1737748107683,
+                "updatedTimestampMs": 1743797381649,
+                "type": "attribute",
+                "key": "27",
+                "value": "711"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "78a8ea09-ff30-43bf-abba-b33c541c9048",
+            "createdTimestampMs": 1737748107690,
+            "updatedTimestampMs": 1743797381764,
+            "name": "preset-10",
+            "deviceValues": [
+              {
+                "id": "b2d7de75-ac8f-40bf-923f-e457cdf2ded2",
+                "createdTimestampMs": 1737748107700,
+                "updatedTimestampMs": 1743797381773,
+                "type": "attribute",
+                "key": "27",
+                "value": "712"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "f7844528-a0b5-4eb3-9d31-e133292f5551",
+            "createdTimestampMs": 1737748107707,
+            "updatedTimestampMs": 1743797381749,
+            "name": "preset-11",
+            "deviceValues": [
+              {
+                "id": "4359a92f-02f2-44fb-b799-bef3867f10de",
+                "createdTimestampMs": 1737748107717,
+                "updatedTimestampMs": 1743797381757,
+                "type": "attribute",
+                "key": "27",
+                "value": "713"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "dcd6c159-5420-4657-8520-f4fe6532a453",
+            "createdTimestampMs": 1737748107588,
+            "updatedTimestampMs": 1743797381655,
+            "name": "preset-04",
+            "deviceValues": [
+              {
+                "id": "4dc5a29e-e264-4ca9-a116-1d7470b32a12",
+                "createdTimestampMs": 1737748107598,
+                "updatedTimestampMs": 1743797381664,
+                "type": "attribute",
+                "key": "27",
+                "value": "706"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "0320e299-3742-457e-8fb3-c23cae36019d",
+            "createdTimestampMs": 1737748107605,
+            "updatedTimestampMs": 1743797381670,
+            "name": "preset-05",
+            "deviceValues": [
+              {
+                "id": "a403f79c-b970-4ade-acca-8371c9633be9",
+                "createdTimestampMs": 1737748107615,
+                "updatedTimestampMs": 1743797381679,
+                "type": "attribute",
+                "key": "27",
+                "value": "707"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "1da03589-a2b4-49f8-8805-19ad2b782597",
+            "createdTimestampMs": 1737748107622,
+            "updatedTimestampMs": 1743797381702,
+            "name": "preset-06",
+            "deviceValues": [
+              {
+                "id": "67d2d190-92c0-43d4-9a68-68a5998ad331",
+                "createdTimestampMs": 1737748107632,
+                "updatedTimestampMs": 1743797381711,
+                "type": "attribute",
+                "key": "27",
+                "value": "708"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "53632682-f6d7-4435-810b-a6e7ccdad08f",
+            "createdTimestampMs": 1737748107741,
+            "updatedTimestampMs": 1743797381686,
+            "name": "preset-13",
+            "deviceValues": [
+              {
+                "id": "26f872cd-21c1-40e3-b938-7b7f80b0e2fc",
+                "createdTimestampMs": 1737748107751,
+                "updatedTimestampMs": 1743797381695,
+                "type": "attribute",
+                "key": "27",
+                "value": "715"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "8f86afc6-5a4e-43fd-979d-f287d038959c",
+            "createdTimestampMs": 1737748107724,
+            "updatedTimestampMs": 1743797381717,
+            "name": "preset-12",
+            "deviceValues": [
+              {
+                "id": "c37d6400-0fe1-4f42-a556-a9db0717dbf8",
+                "createdTimestampMs": 1737748107735,
+                "updatedTimestampMs": 1743797381727,
+                "type": "attribute",
+                "key": "27",
+                "value": "714"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "642f7da4-6832-428f-b52a-d938cc0456f4",
+            "createdTimestampMs": 1737748107640,
+            "updatedTimestampMs": 1743797381795,
+            "name": "preset-07",
+            "deviceValues": [
+              {
+                "id": "6cde5785-1f2b-4010-ad48-cfd631aee65d",
+                "createdTimestampMs": 1737748107650,
+                "updatedTimestampMs": 1743797381805,
+                "type": "attribute",
+                "key": "27",
+                "value": "709"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "d396be48-a394-44fe-8891-10c7a1dbb898",
+            "createdTimestampMs": 1737748107537,
+            "updatedTimestampMs": 1743797381733,
+            "name": "preset-01",
+            "deviceValues": [
+              {
+                "id": "ab28076f-a040-45fd-924a-064c2a6ed5d7",
+                "createdTimestampMs": 1737748107547,
+                "updatedTimestampMs": 1743797381743,
+                "type": "attribute",
+                "key": "27",
+                "value": "703"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "fa2de88d-459f-4f3c-bc51-bd3ea893bc94",
+            "createdTimestampMs": 1737748107657,
+            "updatedTimestampMs": 1743797381827,
+            "name": "preset-08",
+            "deviceValues": [
+              {
+                "id": "68267186-96fa-459a-9b79-fdab2b251df5",
+                "createdTimestampMs": 1737748107667,
+                "updatedTimestampMs": 1743797381836,
+                "type": "attribute",
+                "key": "27",
+                "value": "710"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "8cbf26be-09ea-4a23-aff5-b79d1d0854a8",
+            "createdTimestampMs": 1737748107571,
+            "updatedTimestampMs": 1743797381780,
+            "name": "preset-03",
+            "deviceValues": [
+              {
+                "id": "251bba06-3d1d-4fc1-98fd-518b6d9df6f9",
+                "createdTimestampMs": 1737748107581,
+                "updatedTimestampMs": 1743797381789,
+                "type": "attribute",
+                "key": "27",
+                "value": "705"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "d48f0456-c042-44e7-8c71-a45fd1bbc4bb",
+        "createdTimestampMs": 1737748106206,
+        "updatedTimestampMs": 1743797379268,
+        "functionClass": "arm-exit-delay",
+        "functionInstance": "away",
+        "type": "numeric",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "4fdc03e4-bd5a-48ae-af00-8ab7ea8c67f5",
+            "createdTimestampMs": 1737748106216,
+            "updatedTimestampMs": 1743797379302,
+            "name": "arm-exit-delay-away",
+            "deviceValues": [
+              {
+                "id": "5810dc2a-b61a-47d3-8469-f3706fe280ff",
+                "createdTimestampMs": 1737748106239,
+                "updatedTimestampMs": 1743797379322,
+                "type": "attribute",
+                "key": "3"
+              }
+            ],
+            "range": {
+              "min": 0,
+              "max": 300,
+              "step": 1
+            }
+          }
+        ]
+      },
+      {
+        "id": "6d7ce2de-f5a7-4b8c-91a5-f179025bf425",
+        "createdTimestampMs": 1737748110253,
+        "updatedTimestampMs": 1743797378774,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-19",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "8b57376f-461d-441c-bbeb-840be9157075",
+            "createdTimestampMs": 1737748110263,
+            "updatedTimestampMs": 1743797378781,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "112d35c2-7d8d-4be7-8278-3c684c3d890a",
+                "createdTimestampMs": 1737748110273,
+                "updatedTimestampMs": 1743797378790,
+                "type": "attribute",
+                "key": "319",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "cb958211-1174-424a-85af-ddf0cce4cc08",
+        "createdTimestampMs": 1737748108777,
+        "updatedTimestampMs": 1743797382132,
+        "functionClass": "keyfob-config",
+        "functionInstance": "keyfob-9",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "06901b21-3586-448d-bd68-633777682425",
+            "createdTimestampMs": 1737748108787,
+            "updatedTimestampMs": 1743797382141,
+            "name": "disabled",
+            "deviceValues": [
+              {
+                "id": "621b4a89-3306-4e35-a15c-278c5553b070",
+                "createdTimestampMs": 1737748108798,
+                "updatedTimestampMs": 1743797382150,
+                "type": "attribute",
+                "key": "169",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "dec35816-8fdd-440c-8b68-cde1dcf21d60",
+            "createdTimestampMs": 1737748108804,
+            "updatedTimestampMs": 1743797382174,
+            "name": "enabled",
+            "deviceValues": [
+              {
+                "id": "aafa8a74-e910-4c23-ac63-bf5d9f7b6c27",
+                "createdTimestampMs": 1737748108815,
+                "updatedTimestampMs": 1743797382184,
+                "type": "attribute",
+                "key": "169",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "220c682b-3407-4436-8e48-429dbe4580b8",
+            "createdTimestampMs": 1737748108822,
+            "updatedTimestampMs": 1743797382157,
+            "name": "delete",
+            "deviceValues": [
+              {
+                "id": "70b8add0-ef47-4bab-acad-be0ad35b0b7b",
+                "createdTimestampMs": 1737748108832,
+                "updatedTimestampMs": 1743797382166,
+                "type": "attribute",
+                "key": "169",
+                "value": "2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "8a094d20-8ac7-46e6-b71a-89b4e1dd3cf4",
+        "createdTimestampMs": 1737748108218,
+        "updatedTimestampMs": 1743797378704,
+        "functionClass": "keyfob-state",
+        "functionInstance": "keyfob-8",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "306eaba0-8fbd-4e07-9564-a5bfae0217cc",
+            "createdTimestampMs": 1737748108228,
+            "updatedTimestampMs": 1743797378714,
+            "name": "keyfob-8",
+            "deviceValues": [
+              {
+                "id": "d5d930ea-d3c1-4929-a7a3-b88fb2cac62b",
+                "createdTimestampMs": 1737748108238,
+                "updatedTimestampMs": 1743797378722,
+                "type": "attribute",
+                "key": "158",
+                "format": "security-keyfob-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "ffcfa2b8-f209-4524-97da-31abc466ffec",
+        "createdTimestampMs": 1737748109374,
+        "updatedTimestampMs": 1743797381605,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-18",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "1663d11a-b5ae-46ab-b280-24e1b8d4feb7",
+            "createdTimestampMs": 1737748109384,
+            "updatedTimestampMs": 1743797381614,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "d8243f84-cdfb-485d-8fa2-21cf09e74125",
+                "createdTimestampMs": 1737748109393,
+                "updatedTimestampMs": 1743797381624,
+                "type": "attribute",
+                "key": "218",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "b921d8e4-401b-4257-96b6-9868820497f7",
+        "createdTimestampMs": 1737748106982,
+        "updatedTimestampMs": 1743797378274,
+        "functionClass": "siren-alarm-timeout",
+        "type": "numeric",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "c0335bb6-5e80-48e4-a05f-de4b3b2064fd",
+            "createdTimestampMs": 1737748106992,
+            "updatedTimestampMs": 1743797378282,
+            "name": "siren-alarm-timeout",
+            "deviceValues": [
+              {
+                "id": "c9c519a0-f7d7-4859-aa2a-42dc579770f1",
+                "createdTimestampMs": 1737748107002,
+                "updatedTimestampMs": 1743797378291,
+                "type": "attribute",
+                "key": "24"
+              }
+            ],
+            "range": {
+              "min": 0,
+              "max": 600,
+              "step": 30
+            }
+          }
+        ]
+      },
+      {
+        "id": "9af5e57b-b9e5-4f95-a498-0b2c9f794db0",
+        "createdTimestampMs": 1737748106888,
+        "updatedTimestampMs": 1743797377571,
+        "functionClass": "volume",
+        "functionInstance": "chime",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "24c0c63a-9531-4395-8b9b-2c603d826afa",
+            "createdTimestampMs": 1737748106949,
+            "updatedTimestampMs": 1743797377613,
+            "name": "volume-03",
+            "deviceValues": [
+              {
+                "id": "72a5681e-e8c1-46a4-ac14-7ac8ddef6fcc",
+                "createdTimestampMs": 1737748106959,
+                "updatedTimestampMs": 1743797377623,
+                "type": "attribute",
+                "key": "23",
+                "value": "15"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "744b5c98-0b3f-4db3-bdec-8d4eac7473cb",
+            "createdTimestampMs": 1737748106932,
+            "updatedTimestampMs": 1743797377663,
+            "name": "volume-02",
+            "deviceValues": [
+              {
+                "id": "ab84a060-c8fc-44b2-bd94-92f785d3ba49",
+                "createdTimestampMs": 1737748106942,
+                "updatedTimestampMs": 1743797377673,
+                "type": "attribute",
+                "key": "23",
+                "value": "10"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "160cb15c-55ee-4ec0-937b-84ae4adb1853",
+            "createdTimestampMs": 1737748106915,
+            "updatedTimestampMs": 1743797377631,
+            "name": "volume-01",
+            "deviceValues": [
+              {
+                "id": "2e0f3fc2-1b0f-4194-85b6-f47ee84eb12e",
+                "createdTimestampMs": 1737748106925,
+                "updatedTimestampMs": 1743797377640,
+                "type": "attribute",
+                "key": "23",
+                "value": "6"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "021a6dbb-bb25-4557-8ffc-21493f6946c9",
+            "createdTimestampMs": 1737748106965,
+            "updatedTimestampMs": 1743797377580,
+            "name": "volume-04",
+            "deviceValues": [
+              {
+                "id": "cd58af83-6664-4cba-9a95-809e9abefb0a",
+                "createdTimestampMs": 1737748106975,
+                "updatedTimestampMs": 1743797377600,
+                "type": "attribute",
+                "key": "23",
+                "value": "30"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "68703d98-6d08-4676-ba6c-c9449cde0530",
+            "createdTimestampMs": 1737748106898,
+            "updatedTimestampMs": 1743797377646,
+            "name": "volume-00",
+            "deviceValues": [
+              {
+                "id": "b32ce75c-1d93-4f12-b083-3677d80d0bfd",
+                "createdTimestampMs": 1737748106908,
+                "updatedTimestampMs": 1743797377655,
+                "type": "attribute",
+                "key": "23",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "3a371b49-a883-452f-a963-62b25c56dcc5",
+        "createdTimestampMs": 1737748109056,
+        "updatedTimestampMs": 1743797380066,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-6",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "1188ab3a-c75f-4822-a7e4-a2cd66f476e6",
+            "createdTimestampMs": 1737748109066,
+            "updatedTimestampMs": 1743797380075,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "bdb4b9b4-ab2d-4c11-b4b0-0c25ee456c63",
+                "createdTimestampMs": 1737748109076,
+                "updatedTimestampMs": 1743797380084,
+                "type": "attribute",
+                "key": "206",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "9d51adab-1f26-4aa2-a16b-b3c050e10e67",
+        "createdTimestampMs": 1737748108138,
+        "updatedTimestampMs": 1743797382529,
+        "functionClass": "keyfob-state",
+        "functionInstance": "keyfob-5",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "2351a8e4-6695-4981-9bcc-0f64de54f8ff",
+            "createdTimestampMs": 1737748108148,
+            "updatedTimestampMs": 1743797382540,
+            "name": "keyfob-5",
+            "deviceValues": [
+              {
+                "id": "40c09a15-e426-4c04-a92e-1e52eb79e69c",
+                "createdTimestampMs": 1737748108158,
+                "updatedTimestampMs": 1743797382551,
+                "type": "attribute",
+                "key": "155",
+                "format": "security-keyfob-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "eea2a66e-5891-4c60-b462-0c76a3f8ad4a",
+        "createdTimestampMs": 1737748109900,
+        "updatedTimestampMs": 1743797379123,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-6",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "5492da82-3ac5-4f1a-8089-a53df1260f20",
+            "createdTimestampMs": 1737748109911,
+            "updatedTimestampMs": 1743797379134,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "9f46d1fc-87ea-43b2-bec7-8081b1c5b28a",
+                "createdTimestampMs": 1737748109920,
+                "updatedTimestampMs": 1743797379148,
+                "type": "attribute",
+                "key": "306",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "46632762-ddd6-4637-9871-bca3661d0e08",
+        "createdTimestampMs": 1737748111321,
+        "updatedTimestampMs": 1743797378863,
+        "functionClass": "battery-level",
+        "type": "numeric",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "cd5bacf4-5939-4e69-9716-842932d5af5b",
+            "createdTimestampMs": 1737748111332,
+            "updatedTimestampMs": 1743797378872,
+            "name": "battery-level",
+            "deviceValues": [
+              {
+                "id": "8ca0874e-4a5c-4a3b-b62c-20fc9b691298",
+                "createdTimestampMs": 1737748111342,
+                "updatedTimestampMs": 1743797378895,
+                "type": "attribute",
+                "key": "65079"
+              }
+            ],
+            "range": {
+              "min": 0,
+              "max": 100,
+              "step": 1
+            }
+          }
+        ]
+      },
+      {
+        "id": "921b5465-431a-4b8b-b91f-6af12841148c",
+        "createdTimestampMs": 1737748108111,
+        "updatedTimestampMs": 1743797381429,
+        "functionClass": "keyfob-state",
+        "functionInstance": "keyfob-4",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "4bfa54cc-9d3b-4409-b4f4-6c50b31f113b",
+            "createdTimestampMs": 1737748108121,
+            "updatedTimestampMs": 1743797381438,
+            "name": "keyfob-4",
+            "deviceValues": [
+              {
+                "id": "19f77dc0-15af-4249-8742-d9b5e8d427dc",
+                "createdTimestampMs": 1737748108131,
+                "updatedTimestampMs": 1743797381447,
+                "type": "attribute",
+                "key": "154",
+                "format": "security-keyfob-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "d7044e4d-aced-4272-b207-1cb6c41a8854",
+        "createdTimestampMs": 1737748106178,
+        "updatedTimestampMs": 1743797380745,
+        "functionClass": "arm-exit-delay",
+        "functionInstance": "stay",
+        "type": "numeric",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "26e6c646-645b-4a55-8a68-1346319b0730",
+            "createdTimestampMs": 1737748106188,
+            "updatedTimestampMs": 1743797380757,
+            "name": "arm-exit-delay-stay",
+            "deviceValues": [
+              {
+                "id": "d5628c80-9797-4316-be57-30ffeb90ea81",
+                "createdTimestampMs": 1737748106199,
+                "updatedTimestampMs": 1743797380769,
+                "type": "attribute",
+                "key": "2"
+              }
+            ],
+            "range": {
+              "min": 0,
+              "max": 300,
+              "step": 1
+            }
+          }
+        ]
+      },
+      {
+        "id": "0b8dacc0-b47c-4ac2-99ed-fc7fb2f63c9e",
+        "createdTimestampMs": 1737748106450,
+        "updatedTimestampMs": 1743797379806,
+        "functionClass": "dark-mode",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "050d4a52-90a5-466a-9e15-db77b6ce173f",
+            "createdTimestampMs": 1737748106460,
+            "updatedTimestampMs": 1743797379830,
+            "name": "off",
+            "deviceValues": [
+              {
+                "id": "5a881a0e-e274-4a03-9f12-615035950ee6",
+                "createdTimestampMs": 1737748106469,
+                "updatedTimestampMs": 1743797379839,
+                "type": "attribute",
+                "key": "8",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "637cc635-5a1a-4af8-9aae-02b90d3060f1",
+            "createdTimestampMs": 1737748106477,
+            "updatedTimestampMs": 1743797379814,
+            "name": "on",
+            "deviceValues": [
+              {
+                "id": "a3527e77-e58a-43b3-8013-13793d53874c",
+                "createdTimestampMs": 1737748106487,
+                "updatedTimestampMs": 1743797379823,
+                "type": "attribute",
+                "key": "8",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "f77a4449-a5fe-439e-ba91-201df19c81a1",
+        "createdTimestampMs": 1737748107814,
+        "updatedTimestampMs": 1743797378457,
+        "functionClass": "pin",
+        "functionInstance": "pin-3",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "1667cb65-e314-4d89-9e62-d73e5b154830",
+            "createdTimestampMs": 1737748107824,
+            "updatedTimestampMs": 1743797378465,
+            "name": "pin-3",
+            "deviceValues": [
+              {
+                "id": "6ca7d0ba-13b3-46a1-b2e0-781c5f97c9a1",
+                "createdTimestampMs": 1737748107834,
+                "updatedTimestampMs": 1743797378475,
+                "type": "attribute",
+                "key": "103",
+                "format": "lock-pin"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "d8bd1fb3-413a-4622-8bf6-e67dff4e2942",
+        "createdTimestampMs": 1737748109607,
+        "updatedTimestampMs": 1743797381555,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-27",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "e2127cc9-33e0-4427-a077-958483168045",
+            "createdTimestampMs": 1737748109617,
+            "updatedTimestampMs": 1743797381565,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "03b1e897-c075-4080-ab72-1729b65e9e8f",
+                "createdTimestampMs": 1737748109627,
+                "updatedTimestampMs": 1743797381574,
+                "type": "attribute",
+                "key": "227",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "52fab8fe-7ba0-4e73-a69f-6e5546dc3d1b",
+        "createdTimestampMs": 1737748110334,
+        "updatedTimestampMs": 1743797380919,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-22",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "ecd39e2a-aea3-4613-92c7-ef51da208ad1",
+            "createdTimestampMs": 1737748110344,
+            "updatedTimestampMs": 1743797380927,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "e5bc921a-5a96-4b0d-8f33-2026e5e38fdb",
+                "createdTimestampMs": 1737748110354,
+                "updatedTimestampMs": 1743797380936,
+                "type": "attribute",
+                "key": "322",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "2d58a0d0-4390-4356-8bee-9062f9f149f5",
+        "createdTimestampMs": 1737748109242,
+        "updatedTimestampMs": 1743797379378,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-13",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "d63dc4df-02c7-44cb-9d5a-734ab8064a26",
+            "createdTimestampMs": 1737748109252,
+            "updatedTimestampMs": 1743797379387,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "50d36657-00b4-4e56-9060-c952913458ee",
+                "createdTimestampMs": 1737748109262,
+                "updatedTimestampMs": 1743797379396,
+                "type": "attribute",
+                "key": "213",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "df2448e8-5f2f-4e2c-ba61-04c3d3fa7971",
+        "createdTimestampMs": 1737748109874,
+        "updatedTimestampMs": 1743797382460,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-5",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "abaa595a-dfa5-4908-9135-9a02ae1a4627",
+            "createdTimestampMs": 1737748109884,
+            "updatedTimestampMs": 1743797382469,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "4192af10-eb39-44db-9514-bf972b766cd2",
+                "createdTimestampMs": 1737748109894,
+                "updatedTimestampMs": 1743797382477,
+                "type": "attribute",
+                "key": "305",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "b99fc4c6-c05b-4d25-9480-7e72314c5bad",
+        "createdTimestampMs": 1737748109555,
+        "updatedTimestampMs": 1743797380090,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-25",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "f9776d5a-ecd8-4461-aa2e-2b669239b67b",
+            "createdTimestampMs": 1737748109565,
+            "updatedTimestampMs": 1743797380118,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "60a5047f-658d-419d-afd5-b44a0c023d0a",
+                "createdTimestampMs": 1737748109575,
+                "updatedTimestampMs": 1743797380129,
+                "type": "attribute",
+                "key": "225",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "7ba5d2cb-da07-4294-9281-5f5aff568aa7",
+        "createdTimestampMs": 1737748110038,
+        "updatedTimestampMs": 1743797378298,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-11",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "89f352ca-b109-43c1-8a8b-9ac5de1aaaa6",
+            "createdTimestampMs": 1737748110048,
+            "updatedTimestampMs": 1743797378309,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "a5fd09eb-ae70-4aaa-9c04-d326d176c6b6",
+                "createdTimestampMs": 1737748110058,
+                "updatedTimestampMs": 1743797378318,
+                "type": "attribute",
+                "key": "311",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "c0e47f29-2e48-4d6a-af5c-053ad4c48262",
+        "createdTimestampMs": 1737748108191,
+        "updatedTimestampMs": 1743797378752,
+        "functionClass": "keyfob-state",
+        "functionInstance": "keyfob-7",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "a830a58b-3213-4494-8800-90145c03e572",
+            "createdTimestampMs": 1737748108201,
+            "updatedTimestampMs": 1743797378760,
+            "name": "keyfob-7",
+            "deviceValues": [
+              {
+                "id": "e704f1f1-013a-4164-876a-70dc0c312927",
+                "createdTimestampMs": 1737748108211,
+                "updatedTimestampMs": 1743797378768,
+                "type": "attribute",
+                "key": "157",
+                "format": "security-keyfob-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "1615718d-774d-4175-82d2-2ee2de84b85f",
+        "createdTimestampMs": 1737748106521,
+        "updatedTimestampMs": 1743797381503,
+        "functionClass": "disarm",
+        "type": "string",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "a87e19f4-d334-44cd-b9c0-65d727318873",
+            "createdTimestampMs": 1737748106531,
+            "updatedTimestampMs": 1743797381513,
+            "name": "disarm",
+            "deviceValues": [
+              {
+                "id": "34a0c5fd-fc7a-4201-b241-c079e67d20eb",
+                "createdTimestampMs": 1737748106541,
+                "updatedTimestampMs": 1743797381523,
+                "type": "attribute",
+                "key": "11",
+                "format": "string"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "43ff68d1-3a88-4f61-ae7a-a86f15b235bd",
+        "createdTimestampMs": 1737748109846,
+        "updatedTimestampMs": 1743797379096,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-4",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "d804735f-b7aa-4fc6-82d0-8f8d4f76fad2",
+            "createdTimestampMs": 1737748109856,
+            "updatedTimestampMs": 1743797379106,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "53e96640-d090-4d4c-84f8-efd0ba4dfc8f",
+                "createdTimestampMs": 1737748109867,
+                "updatedTimestampMs": 1743797379115,
+                "type": "attribute",
+                "key": "304",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "cc4a84df-f6f6-4dce-9b04-33053d961811",
+        "createdTimestampMs": 1737748107758,
+        "updatedTimestampMs": 1743797382061,
+        "functionClass": "pin",
+        "functionInstance": "pin-1",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "84d04108-3901-40ae-8991-6c2ef6a21b67",
+            "createdTimestampMs": 1737748107768,
+            "updatedTimestampMs": 1743797382070,
+            "name": "pin-1",
+            "deviceValues": [
+              {
+                "id": "b3c94acd-6f63-471f-8eda-7933fe7c753d",
+                "createdTimestampMs": 1737748107779,
+                "updatedTimestampMs": 1743797382078,
+                "type": "attribute",
+                "key": "101",
+                "format": "lock-pin"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "eb458eb0-35ad-4521-a068-4804dba829f6",
+        "createdTimestampMs": 1737748109503,
+        "updatedTimestampMs": 1743797377759,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-23",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "d365bbc8-700b-4f18-85e5-eaa86270d300",
+            "createdTimestampMs": 1737748109513,
+            "updatedTimestampMs": 1743797377768,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "53739b66-d468-4470-9259-96388b968e41",
+                "createdTimestampMs": 1737748109523,
+                "updatedTimestampMs": 1743797377778,
+                "type": "attribute",
+                "key": "223",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "d0b5d8d5-e2e2-440f-9471-32ef0cb65f8e",
+        "createdTimestampMs": 1737748109029,
+        "updatedTimestampMs": 1743797381991,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-5",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "be5c2d33-c1c2-442c-ad2f-94a22f28d943",
+            "createdTimestampMs": 1737748109040,
+            "updatedTimestampMs": 1743797382000,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "cc209fc4-8661-47e4-9e98-bf6af6c12d6e",
+                "createdTimestampMs": 1737748109050,
+                "updatedTimestampMs": 1743797382009,
+                "type": "attribute",
+                "key": "205",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "8e291a8b-fed5-443a-867d-e005a511f730",
+        "createdTimestampMs": 1737748110522,
+        "updatedTimestampMs": 1743797377785,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-29",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "70364dea-fd4a-4625-b773-0dc5385b71d8",
+            "createdTimestampMs": 1737748110532,
+            "updatedTimestampMs": 1743797377793,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "ddf2eaec-9ff7-4476-b9e2-70769fbb3400",
+                "createdTimestampMs": 1737748110542,
+                "updatedTimestampMs": 1743797377802,
+                "type": "attribute",
+                "key": "329",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "d2c101f8-1c92-4667-bf03-f315957a8317",
+        "createdTimestampMs": 1737748108977,
+        "updatedTimestampMs": 1743797382413,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-3",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "23edc7ad-5d3a-404e-8067-7bd09915ca23",
+            "createdTimestampMs": 1737748108986,
+            "updatedTimestampMs": 1743797382421,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "ece3841d-af59-496b-bf3e-06af2e6ab324",
+                "createdTimestampMs": 1737748108996,
+                "updatedTimestampMs": 1743797382430,
+                "type": "attribute",
+                "key": "203",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "ae93215d-bb73-4a7a-bea5-68a517e89d52",
+        "createdTimestampMs": 1737748110605,
+        "updatedTimestampMs": 1743797382483,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-32",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "4536ba09-5a91-4d07-a629-527724842e3b",
+            "createdTimestampMs": 1737748110615,
+            "updatedTimestampMs": 1743797382491,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "4b0027a2-b07a-4437-8830-ee6d5a2a37e6",
+                "createdTimestampMs": 1737748110624,
+                "updatedTimestampMs": 1743797382500,
+                "type": "attribute",
+                "key": "332",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "38ca5a06-610d-4db5-94c0-ec235b2f07c0",
+        "createdTimestampMs": 1737748107786,
+        "updatedTimestampMs": 1743797379497,
+        "functionClass": "pin",
+        "functionInstance": "pin-2",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "79a8cb09-dbf4-436e-a21f-fd569202e2b1",
+            "createdTimestampMs": 1737748107796,
+            "updatedTimestampMs": 1743797379507,
+            "name": "pin-2",
+            "deviceValues": [
+              {
+                "id": "49282f26-63bc-4a50-af0d-0461e515df99",
+                "createdTimestampMs": 1737748107806,
+                "updatedTimestampMs": 1743797379517,
+                "type": "attribute",
+                "key": "102",
+                "format": "lock-pin"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "51a07f86-16bf-4725-8582-6dc9ba617ec3",
+        "createdTimestampMs": 1737748108479,
+        "updatedTimestampMs": 1743797381347,
+        "functionClass": "keyfob-config",
+        "functionInstance": "keyfob-4",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "f97d9c3b-aecf-4ee0-8685-b244190a02b2",
+            "createdTimestampMs": 1737748108522,
+            "updatedTimestampMs": 1743797381385,
+            "name": "delete",
+            "deviceValues": [
+              {
+                "id": "e3cfd444-4493-4fbb-9462-4b378f3bd017",
+                "createdTimestampMs": 1737748108532,
+                "updatedTimestampMs": 1743797381396,
+                "type": "attribute",
+                "key": "164",
+                "value": "2"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "226f5459-8366-45b6-9106-cd09d704bf72",
+            "createdTimestampMs": 1737748108489,
+            "updatedTimestampMs": 1743797381355,
+            "name": "disabled",
+            "deviceValues": [
+              {
+                "id": "612fc5e1-0cf7-4ddb-a18a-9c30fc1cb4ac",
+                "createdTimestampMs": 1737748108499,
+                "updatedTimestampMs": 1743797381364,
+                "type": "attribute",
+                "key": "164",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "ec4de589-440f-4663-bbe5-e37dc13139fa",
+            "createdTimestampMs": 1737748108506,
+            "updatedTimestampMs": 1743797381370,
+            "name": "enabled",
+            "deviceValues": [
+              {
+                "id": "839260b0-6a61-4051-a5d3-8f25393346e2",
+                "createdTimestampMs": 1737748108515,
+                "updatedTimestampMs": 1743797381379,
+                "type": "attribute",
+                "key": "164",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "9ef94b32-7a54-4266-9b5f-2d4457ac5783",
+        "createdTimestampMs": 1737748109348,
+        "updatedTimestampMs": 1743797379595,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-17",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "e0dae7a7-4bd7-497e-a52f-38e01f443ab1",
+            "createdTimestampMs": 1737748109357,
+            "updatedTimestampMs": 1743797379603,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "55995bd5-efdd-40e2-be22-832940e7865e",
+                "createdTimestampMs": 1737748109367,
+                "updatedTimestampMs": 1743797379612,
+                "type": "attribute",
+                "key": "217",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "15a6ccde-aafd-45c7-90c1-501b7d11dd79",
+        "createdTimestampMs": 1737748108598,
+        "updatedTimestampMs": 1743797379896,
+        "functionClass": "keyfob-config",
+        "functionInstance": "keyfob-6",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "c0e3fee7-d219-4610-9d17-e7df42e8b302",
+            "createdTimestampMs": 1737748108608,
+            "updatedTimestampMs": 1743797379922,
+            "name": "disabled",
+            "deviceValues": [
+              {
+                "id": "91d71cd2-e973-4ba2-8e55-22794b4b923d",
+                "createdTimestampMs": 1737748108618,
+                "updatedTimestampMs": 1743797379932,
+                "type": "attribute",
+                "key": "166",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "b5f9a6cc-acfd-4ff3-9e13-9ff1f215cd14",
+            "createdTimestampMs": 1737748108624,
+            "updatedTimestampMs": 1743797379907,
+            "name": "enabled",
+            "deviceValues": [
+              {
+                "id": "9518365c-1205-4fd3-adde-b09372207eab",
+                "createdTimestampMs": 1737748108633,
+                "updatedTimestampMs": 1743797379916,
+                "type": "attribute",
+                "key": "166",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "d5e42664-5af1-4563-ad61-a2fdaf8107ea",
+            "createdTimestampMs": 1737748108640,
+            "updatedTimestampMs": 1743797379938,
+            "name": "delete",
+            "deviceValues": [
+              {
+                "id": "d25e98e4-7ae2-43b8-8a1d-0855772ead2d",
+                "createdTimestampMs": 1737748108650,
+                "updatedTimestampMs": 1743797379947,
+                "type": "attribute",
+                "key": "166",
+                "value": "2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "baa4cfb1-b40e-4a11-aa78-cff565def0df",
+        "createdTimestampMs": 1737748109477,
+        "updatedTimestampMs": 1743797379954,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-22",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "88c6b4f7-f4ef-4eea-849f-6d73ca278f29",
+            "createdTimestampMs": 1737748109487,
+            "updatedTimestampMs": 1743797379963,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "ec4f7213-9722-4746-b183-01dcada10c1d",
+                "createdTimestampMs": 1737748109496,
+                "updatedTimestampMs": 1743797379972,
+                "type": "attribute",
+                "key": "222",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "7edd916f-4c92-4b05-8c6b-05cabdce4c72",
+        "createdTimestampMs": 1737748108897,
+        "updatedTimestampMs": 1743797378839,
+        "functionClass": "keypad-device-id",
+        "type": "string",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "84852dce-2b84-4e39-b93c-deb5c815531d",
+            "createdTimestampMs": 1737748108907,
+            "updatedTimestampMs": 1743797378847,
+            "name": "keypad-device-id",
+            "deviceValues": [
+              {
+                "id": "6364f4de-cad1-4379-8c23-00a667683a7d",
+                "createdTimestampMs": 1737748108917,
+                "updatedTimestampMs": 1743797378856,
+                "type": "attribute",
+                "key": "200",
+                "format": "string"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "61394e60-dd7e-477b-b62a-a92a3eb9de4c",
+        "createdTimestampMs": 1737748109188,
+        "updatedTimestampMs": 1743797379219,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-11",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "517744c7-f26f-4b95-915a-e300f9ebb5f7",
+            "createdTimestampMs": 1737748109198,
+            "updatedTimestampMs": 1743797379234,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "36a945b5-ec5a-487f-860c-0945fee5af37",
+                "createdTimestampMs": 1737748109208,
+                "updatedTimestampMs": 1743797379252,
+                "type": "attribute",
+                "key": "211",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "24062311-527c-40d4-9ca5-a1e321be7a39",
+        "createdTimestampMs": 1737748108029,
+        "updatedTimestampMs": 1743797378656,
+        "functionClass": "keyfob-state",
+        "functionInstance": "keyfob-1",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "45d2c0ea-d2c5-4a56-86f1-8bd8c4903e23",
+            "createdTimestampMs": 1737748108040,
+            "updatedTimestampMs": 1743797378664,
+            "name": "keyfob-1",
+            "deviceValues": [
+              {
+                "id": "da74dbea-7580-4848-a8ec-3683de0309c8",
+                "createdTimestampMs": 1737748108050,
+                "updatedTimestampMs": 1743797378673,
+                "type": "attribute",
+                "key": "151",
+                "format": "security-keyfob-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "7e80824a-5ec4-46a8-b400-8724b920f817",
+        "createdTimestampMs": 1737748109712,
+        "updatedTimestampMs": 1743797382191,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-31",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "c55c38a2-b973-4bc2-a5b7-8d1e76ba1317",
+            "createdTimestampMs": 1737748109722,
+            "updatedTimestampMs": 1743797382200,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "a4f51dd3-d9cd-49ee-9edb-4d44d1794599",
+                "createdTimestampMs": 1737748109733,
+                "updatedTimestampMs": 1743797382209,
+                "type": "attribute",
+                "key": "231",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "326059b1-b705-4e91-b385-02b0c24874ec",
+        "createdTimestampMs": 1737748110495,
+        "updatedTimestampMs": 1743797377972,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-28",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "b3ab8440-b95c-49f1-b36d-fd9211311e61",
+            "createdTimestampMs": 1737748110505,
+            "updatedTimestampMs": 1743797377982,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "eee6859b-cb82-4a71-8afd-7c0ed8b2db7f",
+                "createdTimestampMs": 1737748110515,
+                "updatedTimestampMs": 1743797377991,
+                "type": "attribute",
+                "key": "328",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "1b46bd6b-70dc-4ca0-b299-326f5c2e88b4",
+        "createdTimestampMs": 1737748109953,
+        "updatedTimestampMs": 1743797380977,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-8",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "062f2bfd-f746-4a37-947f-24aff06a7774",
+            "createdTimestampMs": 1737748109963,
+            "updatedTimestampMs": 1743797380989,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "dd3a8750-017d-48f0-bf7c-6c778fbfade3",
+                "createdTimestampMs": 1737748109972,
+                "updatedTimestampMs": 1743797380999,
+                "type": "attribute",
+                "key": "308",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "2fe81409-1aa7-41f1-9c82-014bb3e1e47b",
+        "createdTimestampMs": 1737748106655,
+        "updatedTimestampMs": 1743797382558,
+        "functionClass": "volume",
+        "functionInstance": "exit-delay-away",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "fe5ca0a9-4dd3-4166-807d-00c8c754aac7",
+            "createdTimestampMs": 1737748106722,
+            "updatedTimestampMs": 1743797382566,
+            "name": "volume-02",
+            "deviceValues": [
+              {
+                "id": "97da5be9-a299-4f62-a6d6-c1ee3ad78df2",
+                "createdTimestampMs": 1737748106750,
+                "updatedTimestampMs": 1743797382575,
+                "type": "attribute",
+                "key": "21",
+                "value": "10"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "3fd7e8c3-e807-4373-83f0-1638c44d5f66",
+            "createdTimestampMs": 1737748106665,
+            "updatedTimestampMs": 1743797382628,
+            "name": "volume-00",
+            "deviceValues": [
+              {
+                "id": "4bd29ba2-782d-4a1e-a323-fb2372e4675b",
+                "createdTimestampMs": 1737748106675,
+                "updatedTimestampMs": 1743797382637,
+                "type": "attribute",
+                "key": "21",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "8bdadebf-596b-411b-b99e-faae1ae628b4",
+            "createdTimestampMs": 1737748106757,
+            "updatedTimestampMs": 1743797382613,
+            "name": "volume-03",
+            "deviceValues": [
+              {
+                "id": "74d4b00c-78c9-4dd8-b552-16eab579463b",
+                "createdTimestampMs": 1737748106767,
+                "updatedTimestampMs": 1743797382622,
+                "type": "attribute",
+                "key": "21",
+                "value": "15"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "85f65c0a-ff7b-402d-9eda-68806187f8f8",
+            "createdTimestampMs": 1737748106774,
+            "updatedTimestampMs": 1743797382582,
+            "name": "volume-04",
+            "deviceValues": [
+              {
+                "id": "123756e0-8c8d-436b-881c-74518dfc2111",
+                "createdTimestampMs": 1737748106784,
+                "updatedTimestampMs": 1743797382590,
+                "type": "attribute",
+                "key": "21",
+                "value": "30"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "fbb2b9ff-7fbd-4b08-b800-6b72137d658b",
+            "createdTimestampMs": 1737748106682,
+            "updatedTimestampMs": 1743797382596,
+            "name": "volume-01",
+            "deviceValues": [
+              {
+                "id": "f096d400-b266-403b-9bc4-3a9d4dd0347f",
+                "createdTimestampMs": 1737748106692,
+                "updatedTimestampMs": 1743797382606,
+                "type": "attribute",
+                "key": "21",
+                "value": "6"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "1d609f45-28ef-4736-95f8-3df9c8e9d6bc",
+        "createdTimestampMs": 1737748110170,
+        "updatedTimestampMs": 1743797380716,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-16",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "927fa519-91a1-475b-bccd-6c2bfc2230a4",
+            "createdTimestampMs": 1737748110180,
+            "updatedTimestampMs": 1743797380729,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "953b5b3a-36f4-47d0-b24c-096377ba6663",
+                "createdTimestampMs": 1737748110190,
+                "updatedTimestampMs": 1743797380738,
+                "type": "attribute",
+                "key": "316",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "d0232cbc-411e-485f-8a0f-5561b8622de6",
+        "createdTimestampMs": 1737748110307,
+        "updatedTimestampMs": 1743797381843,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-21",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "25ab6aa4-e3a6-4fdb-b536-f296c2202c2d",
+            "createdTimestampMs": 1737748110317,
+            "updatedTimestampMs": 1743797381853,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "8bc52320-eb58-445c-8c54-bca78f16be14",
+                "createdTimestampMs": 1737748110327,
+                "updatedTimestampMs": 1743797381862,
+                "type": "attribute",
+                "key": "321",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "49394b64-33cc-46eb-83ba-186d9f19027a",
+        "createdTimestampMs": 1737748110361,
+        "updatedTimestampMs": 1743797379425,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-23",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "294e230d-6d32-438d-afdd-ba571faf3833",
+            "createdTimestampMs": 1737748110371,
+            "updatedTimestampMs": 1743797379433,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "48c70b4e-3eb1-4e98-9720-eabe2d4df26a",
+                "createdTimestampMs": 1737748110381,
+                "updatedTimestampMs": 1743797379441,
+                "type": "attribute",
+                "key": "323",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "3566e0f1-ae1c-4335-b83c-77f73941d25b",
+        "createdTimestampMs": 1737748109767,
+        "updatedTimestampMs": 1743797379780,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-1",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "2a7d7ced-d44d-44af-b16d-0e4ad593f0af",
+            "createdTimestampMs": 1737748109776,
+            "updatedTimestampMs": 1743797379790,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "de09bcaf-1b55-4a2b-b9f6-ae7aa228f658",
+                "createdTimestampMs": 1737748109786,
+                "updatedTimestampMs": 1743797379799,
+                "type": "attribute",
+                "key": "301",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "853f3265-3cc9-4b7b-8b75-2c5e6cf18333",
+        "createdTimestampMs": 1737748108924,
+        "updatedTimestampMs": 1743797380892,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-1",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "1b54767f-8320-46ce-9a59-e7fe6a86c103",
+            "createdTimestampMs": 1737748108933,
+            "updatedTimestampMs": 1743797380903,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "e7b10473-cfad-4d6c-bb3c-5ea823fe250a",
+                "createdTimestampMs": 1737748108943,
+                "updatedTimestampMs": 1743797380912,
+                "type": "attribute",
+                "key": "201",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "3dc42d4a-b9eb-41a6-bc9e-c09363877bcf",
+        "createdTimestampMs": 1737748110388,
+        "updatedTimestampMs": 1743797377903,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-24",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "4cdd5750-16f5-456e-9b3e-9553f817e2d8",
+            "createdTimestampMs": 1737748110398,
+            "updatedTimestampMs": 1743797377913,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "44c687f3-15b0-4475-8a7b-d873c264dc6c",
+                "createdTimestampMs": 1737748110408,
+                "updatedTimestampMs": 1743797377921,
+                "type": "attribute",
+                "key": "324",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "2894bed4-2b8b-4073-9eac-bbc186dea023",
+        "createdTimestampMs": 1737748107975,
+        "updatedTimestampMs": 1743797380776,
+        "functionClass": "pin",
+        "functionInstance": "pin-9",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "21c1cb39-bd01-4409-8416-41aa5704af00",
+            "createdTimestampMs": 1737748107986,
+            "updatedTimestampMs": 1743797380787,
+            "name": "pin-9",
+            "deviceValues": [
+              {
+                "id": "36e8376a-0f9d-45fa-8d01-38c3d5e4423e",
+                "createdTimestampMs": 1737748107996,
+                "updatedTimestampMs": 1743797380796,
+                "type": "attribute",
+                "key": "109",
+                "format": "lock-pin"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "7af6ab30-c103-41d6-aa8e-8deef94b99ee",
+        "createdTimestampMs": 1737748106275,
+        "updatedTimestampMs": 1743797377880,
+        "functionClass": "temporary-bypass-time",
+        "type": "numeric",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "c4f522b4-67c8-4c9b-adc1-62a564fa5149",
+            "createdTimestampMs": 1737748106285,
+            "updatedTimestampMs": 1743797377888,
+            "name": "temporary-bypass-time",
+            "deviceValues": [
+              {
+                "id": "fd4519ff-8e06-4069-936f-9c777dcd8c10",
+                "createdTimestampMs": 1737748106294,
+                "updatedTimestampMs": 1743797377897,
+                "type": "attribute",
+                "key": "5"
+              }
+            ],
+            "range": {
+              "min": 10,
+              "max": 300,
+              "step": 1
+            }
+          }
+        ]
+      },
+      {
+        "id": "6baaa45b-f6e3-4787-983a-1647784b3c48",
+        "createdTimestampMs": 1737748109134,
+        "updatedTimestampMs": 1743797382084,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-9",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "2e208f76-f8d3-4101-9402-de1f99d200fb",
+            "createdTimestampMs": 1737748109143,
+            "updatedTimestampMs": 1743797382092,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "848eabde-a06e-4e5f-84fc-7d68cae784a5",
+                "createdTimestampMs": 1737748109153,
+                "updatedTimestampMs": 1743797382101,
+                "type": "attribute",
+                "key": "209",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "e12e0378-476e-47e6-9275-8b51b9f28c56",
+        "createdTimestampMs": 1737748109529,
+        "updatedTimestampMs": 1743797381892,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-24",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "b4f0b876-b2ff-4007-8ffa-a3b290ae9b71",
+            "createdTimestampMs": 1737748109539,
+            "updatedTimestampMs": 1743797381901,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "a70644fd-9029-4d8b-88ca-9af1b2216e4a",
+                "createdTimestampMs": 1737748109548,
+                "updatedTimestampMs": 1743797381909,
+                "type": "attribute",
+                "key": "224",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "4762cb26-655c-445d-b4c5-85e849618f2d",
+        "createdTimestampMs": 1737748109294,
+        "updatedTimestampMs": 1743797377734,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-15",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "a0571fa3-9377-46a4-a0ec-68b7f0307ec2",
+            "createdTimestampMs": 1737748109304,
+            "updatedTimestampMs": 1743797377744,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "81830b73-f188-47f7-a451-5e14e3df30e8",
+                "createdTimestampMs": 1737748109314,
+                "updatedTimestampMs": 1743797377752,
+                "type": "attribute",
+                "key": "215",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "8d91b507-62e7-4fe7-8fda-ea3987d9c529",
+        "createdTimestampMs": 1737748108271,
+        "updatedTimestampMs": 1743797381868,
+        "functionClass": "keyfob-state",
+        "functionInstance": "keyfob-10",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "d0791136-6f30-475a-8bf0-b29d39f12941",
+            "createdTimestampMs": 1737748108281,
+            "updatedTimestampMs": 1743797381877,
+            "name": "keyfob-10",
+            "deviceValues": [
+              {
+                "id": "8a5dd259-dc72-451f-8fff-643fe625cc94",
+                "createdTimestampMs": 1737748108291,
+                "updatedTimestampMs": 1743797381886,
+                "type": "attribute",
+                "key": "160",
+                "format": "security-keyfob-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "2e247479-98c1-4958-879a-f325169b117b",
+        "createdTimestampMs": 1737748109268,
+        "updatedTimestampMs": 1743797379732,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-14",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "ddf80039-1e6b-4e74-a866-f77f0ee1c30d",
+            "createdTimestampMs": 1737748109278,
+            "updatedTimestampMs": 1743797379741,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "e7d56ef3-0cd8-40e1-9756-111e72628c50",
+                "createdTimestampMs": 1737748109288,
+                "updatedTimestampMs": 1743797379749,
+                "type": "attribute",
+                "key": "214",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "fd5e4378-ee44-4410-9143-9dd1e86d1d87",
+        "createdTimestampMs": 1737748105725,
+        "updatedTimestampMs": 1743797378505,
+        "functionClass": "alarm-state",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "aa74293d-2280-4667-ba5f-cdbda516cdd2",
+            "createdTimestampMs": 1737748106068,
+            "updatedTimestampMs": 1743797378640,
+            "name": "arm-away",
+            "deviceValues": [
+              {
+                "id": "d29bb384-4adc-4610-9c68-897f9670f525",
+                "createdTimestampMs": 1737748106079,
+                "updatedTimestampMs": 1743797378650,
+                "type": "attribute",
+                "key": "1",
+                "value": "3"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "bbff5704-9734-4c9d-af0f-503990e25935",
+            "createdTimestampMs": 1737748106159,
+            "updatedTimestampMs": 1743797378613,
+            "name": "learning",
+            "deviceValues": [
+              {
+                "id": "0c222360-e3ef-4e7d-8521-19ebf481ee29",
+                "createdTimestampMs": 1737748106170,
+                "updatedTimestampMs": 1743797378622,
+                "type": "attribute",
+                "key": "1",
+                "value": "8"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "f3c96e25-c38e-435f-b06f-3e67dcd9f71f",
+            "createdTimestampMs": 1737748106121,
+            "updatedTimestampMs": 1743797378540,
+            "name": "alarming",
+            "deviceValues": [
+              {
+                "id": "ab7e9b52-b407-47ca-8b9e-070437f2dc59",
+                "createdTimestampMs": 1737748106132,
+                "updatedTimestampMs": 1743797378548,
+                "type": "attribute",
+                "key": "1",
+                "value": "6"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "7e7b9fe0-4c1f-44ba-9bab-23bdda39d9b6",
+            "createdTimestampMs": 1737748106140,
+            "updatedTimestampMs": 1743797378513,
+            "name": "alarming-sos",
+            "deviceValues": [
+              {
+                "id": "899256bd-e1de-4eb6-9b45-8dbba8ef6d06",
+                "createdTimestampMs": 1737748106151,
+                "updatedTimestampMs": 1743797378520,
+                "type": "attribute",
+                "key": "1",
+                "value": "7"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "9a987866-0d66-4e97-b28a-dfbf1491c57f",
+            "createdTimestampMs": 1737748106086,
+            "updatedTimestampMs": 1743797378554,
+            "name": "arm-stay",
+            "deviceValues": [
+              {
+                "id": "4427d11f-e4cd-4980-8cbb-66c446d1d4c7",
+                "createdTimestampMs": 1737748106096,
+                "updatedTimestampMs": 1743797378563,
+                "type": "attribute",
+                "key": "1",
+                "value": "4"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "3f137f00-d71d-41f1-935f-1ed672d75a80",
+            "createdTimestampMs": 1737748106050,
+            "updatedTimestampMs": 1743797378570,
+            "name": "arm-started-stay",
+            "deviceValues": [
+              {
+                "id": "fafe58ed-cd43-486b-84a0-79f5469d8310",
+                "createdTimestampMs": 1737748106060,
+                "updatedTimestampMs": 1743797378578,
+                "type": "attribute",
+                "key": "1",
+                "value": "2"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "64af0b83-b412-48e1-95e8-fc05e7e19a21",
+            "createdTimestampMs": 1737748105840,
+            "updatedTimestampMs": 1743797378599,
+            "name": "disarmed",
+            "deviceValues": [
+              {
+                "id": "e850241d-9e82-4576-82ec-e5f3c4c9a041",
+                "createdTimestampMs": 1737748105945,
+                "updatedTimestampMs": 1743797378607,
+                "type": "attribute",
+                "key": "1",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "f2758e71-6e0d-4b45-b61f-cf21f6d71637",
+            "createdTimestampMs": 1737748106103,
+            "updatedTimestampMs": 1743797378584,
+            "name": "triggered",
+            "deviceValues": [
+              {
+                "id": "40b71ea0-71a4-4f05-951a-33513cdd5766",
+                "createdTimestampMs": 1737748106114,
+                "updatedTimestampMs": 1743797378593,
+                "type": "attribute",
+                "key": "1",
+                "value": "5"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "58a72899-7422-4d77-badd-6a21194ab584",
+            "createdTimestampMs": 1737748106026,
+            "updatedTimestampMs": 1743797378527,
+            "name": "arm-started-away",
+            "deviceValues": [
+              {
+                "id": "af4a082c-3418-4011-9c7c-b4f3042f4031",
+                "createdTimestampMs": 1737748106037,
+                "updatedTimestampMs": 1743797378534,
+                "type": "attribute",
+                "key": "1",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "90d53482-48f9-45b3-8323-f8b56eff96f9",
+        "createdTimestampMs": 1737748108358,
+        "updatedTimestampMs": 1743797377829,
+        "functionClass": "keyfob-config",
+        "functionInstance": "keyfob-2",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "dff607f7-da19-42c2-a993-fa8fd458a82e",
+            "createdTimestampMs": 1737748108402,
+            "updatedTimestampMs": 1743797377853,
+            "name": "delete",
+            "deviceValues": [
+              {
+                "id": "0425b2ad-99a9-4dcf-94f5-db0f1f895bf4",
+                "createdTimestampMs": 1737748108412,
+                "updatedTimestampMs": 1743797377861,
+                "type": "attribute",
+                "key": "162",
+                "value": "2"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "6f831bd6-3cd3-4a6f-9600-bdf251eedd15",
+            "createdTimestampMs": 1737748108368,
+            "updatedTimestampMs": 1743797377838,
+            "name": "disabled",
+            "deviceValues": [
+              {
+                "id": "7d0c337a-cea7-4728-a34f-26d25865f907",
+                "createdTimestampMs": 1737748108378,
+                "updatedTimestampMs": 1743797377847,
+                "type": "attribute",
+                "key": "162",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "8107cc90-37b1-44bc-ae82-00784d108414",
+            "createdTimestampMs": 1737748108385,
+            "updatedTimestampMs": 1743797377866,
+            "name": "enabled",
+            "deviceValues": [
+              {
+                "id": "6d8e425e-88ea-4c9d-9568-d4da8e28eff1",
+                "createdTimestampMs": 1737748108395,
+                "updatedTimestampMs": 1743797377874,
+                "type": "attribute",
+                "key": "162",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "e0a0689b-7297-4801-9ce7-62796d14a35a",
+        "createdTimestampMs": 1737748108298,
+        "updatedTimestampMs": 1743797379620,
+        "functionClass": "keyfob-config",
+        "functionInstance": "keyfob-1",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "8b8fdefb-d574-4a6e-ad6a-5367e0855641",
+            "createdTimestampMs": 1737748108341,
+            "updatedTimestampMs": 1743797379645,
+            "name": "delete",
+            "deviceValues": [
+              {
+                "id": "d680900d-f078-496f-a142-d7b778133a8b",
+                "createdTimestampMs": 1737748108351,
+                "updatedTimestampMs": 1743797379655,
+                "type": "attribute",
+                "key": "161",
+                "value": "2"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "96b8e2ae-180e-4627-9c33-73e11d14226c",
+            "createdTimestampMs": 1737748108324,
+            "updatedTimestampMs": 1743797379630,
+            "name": "enabled",
+            "deviceValues": [
+              {
+                "id": "e228e59f-9401-4e9c-a941-76fb0222e5b7",
+                "createdTimestampMs": 1737748108334,
+                "updatedTimestampMs": 1743797379639,
+                "type": "attribute",
+                "key": "161",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "c75f0c4a-8e21-464d-9e1e-6771cd70aa6b",
+            "createdTimestampMs": 1737748108307,
+            "updatedTimestampMs": 1743797379661,
+            "name": "disabled",
+            "deviceValues": [
+              {
+                "id": "a8d737dc-3267-4be3-9468-34f143a0cc97",
+                "createdTimestampMs": 1737748108317,
+                "updatedTimestampMs": 1743797379671,
+                "type": "attribute",
+                "key": "161",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "26c9f736-2c01-470f-b654-2668c941afe3",
+        "createdTimestampMs": 1737748108656,
+        "updatedTimestampMs": 1743797382643,
+        "functionClass": "keyfob-config",
+        "functionInstance": "keyfob-7",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "65d12ff1-b820-4593-b370-8cfb6282acbd",
+            "createdTimestampMs": 1737748108666,
+            "updatedTimestampMs": 1743797382652,
+            "name": "disabled",
+            "deviceValues": [
+              {
+                "id": "ea160838-0e54-4594-a495-09e82d471368",
+                "createdTimestampMs": 1737748108676,
+                "updatedTimestampMs": 1743797382661,
+                "type": "attribute",
+                "key": "167",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "bd477fc0-956e-4819-a0d3-4b5ef112b106",
+            "createdTimestampMs": 1737748108682,
+            "updatedTimestampMs": 1743797382681,
+            "name": "enabled",
+            "deviceValues": [
+              {
+                "id": "f4d3aedd-247f-4993-9b54-f774eba9ab72",
+                "createdTimestampMs": 1737748108692,
+                "updatedTimestampMs": 1743797382689,
+                "type": "attribute",
+                "key": "167",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "e2718d97-2c9b-4a59-80d3-6b62bb5719bf",
+            "createdTimestampMs": 1737748108699,
+            "updatedTimestampMs": 1743797382666,
+            "name": "delete",
+            "deviceValues": [
+              {
+                "id": "a5921bf6-4e81-46bf-9b16-28e94291f1ab",
+                "createdTimestampMs": 1737748108708,
+                "updatedTimestampMs": 1743797382675,
+                "type": "attribute",
+                "key": "167",
+                "value": "2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "f40868b6-ed17-4f9c-8008-83d7c95b92fa",
+        "createdTimestampMs": 1737748109660,
+        "updatedTimestampMs": 1743797381580,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-29",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "da0b1d66-9127-431f-9c1a-662cc5015657",
+            "createdTimestampMs": 1737748109670,
+            "updatedTimestampMs": 1743797381589,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "61ba632a-0665-45f9-a942-302f5c0dc5a7",
+                "createdTimestampMs": 1737748109679,
+                "updatedTimestampMs": 1743797381598,
+                "type": "attribute",
+                "key": "229",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "8f6c76f0-671e-4e5c-bf3b-9875432347cf",
+        "createdTimestampMs": 1737748108245,
+        "updatedTimestampMs": 1743797379845,
+        "functionClass": "keyfob-state",
+        "functionInstance": "keyfob-9",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "e1d3a818-9e32-487e-a53c-072e495d13b4",
+            "createdTimestampMs": 1737748108255,
+            "updatedTimestampMs": 1743797379854,
+            "name": "keyfob-9",
+            "deviceValues": [
+              {
+                "id": "0bd9a5fe-b280-4a8b-a0e1-762ee3597161",
+                "createdTimestampMs": 1737748108265,
+                "updatedTimestampMs": 1743797379863,
+                "type": "attribute",
+                "key": "159",
+                "format": "security-keyfob-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "6f60c3c4-7d1d-4394-80cd-d375491bfed5",
+        "createdTimestampMs": 1737748109425,
+        "updatedTimestampMs": 1743797382038,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-20",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "3cb8762a-aa13-4422-86bc-c9adbed99ee6",
+            "createdTimestampMs": 1737748109435,
+            "updatedTimestampMs": 1743797382047,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "3071656a-f1ee-4b08-9e4f-29eea367bec1",
+                "createdTimestampMs": 1737748109445,
+                "updatedTimestampMs": 1743797382056,
+                "type": "attribute",
+                "key": "220",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "06e4a6b3-4b86-457b-b0fe-0470edd08ab9",
+        "createdTimestampMs": 1737748108057,
+        "updatedTimestampMs": 1743797380867,
+        "functionClass": "keyfob-state",
+        "functionInstance": "keyfob-2",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "21451bb0-7f2b-4b94-ae18-b24dbad6f89e",
+            "createdTimestampMs": 1737748108067,
+            "updatedTimestampMs": 1743797380876,
+            "name": "keyfob-2",
+            "deviceValues": [
+              {
+                "id": "42aee51f-2ba6-4864-8409-09ded8d38b1a",
+                "createdTimestampMs": 1737748108077,
+                "updatedTimestampMs": 1743797380885,
+                "type": "attribute",
+                "key": "152",
+                "format": "security-keyfob-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "0e1236f3-ce74-4f81-a871-86053a7abc57",
+        "createdTimestampMs": 1737748106247,
+        "updatedTimestampMs": 1743797379473,
+        "functionClass": "disarm-entry-delay",
+        "type": "numeric",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "5eba9de5-9b1b-45a3-81b7-c28599275ef2",
+            "createdTimestampMs": 1737748106257,
+            "updatedTimestampMs": 1743797379482,
+            "name": "disarm-entry-delay",
+            "deviceValues": [
+              {
+                "id": "6c296360-6f2b-40c0-ab58-c31dc5bc6ec4",
+                "createdTimestampMs": 1737748106268,
+                "updatedTimestampMs": 1743797379490,
+                "type": "attribute",
+                "key": "4"
+              }
+            ],
+            "range": {
+              "min": 1,
+              "max": 300,
+              "step": 1
+            }
+          }
+        ]
+      },
+      {
+        "id": "6c899e61-1266-40ab-a079-71f13f15525a",
+        "createdTimestampMs": 1737748109686,
+        "updatedTimestampMs": 1743797378728,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-30",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "0845e374-f2e4-44b4-8e49-2e25168c16bd",
+            "createdTimestampMs": 1737748109696,
+            "updatedTimestampMs": 1743797378737,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "0e9797f4-b7fc-45b1-b68d-8333752c1a4f",
+                "createdTimestampMs": 1737748109706,
+                "updatedTimestampMs": 1743797378746,
+                "type": "attribute",
+                "key": "230",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "83558240-8070-4b98-868e-d89b2201e861",
+        "createdTimestampMs": 1737748108950,
+        "updatedTimestampMs": 1743797378239,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-2",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "3ba5f34f-4cec-4424-9e64-656aedd45546",
+            "createdTimestampMs": 1737748108960,
+            "updatedTimestampMs": 1743797378249,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "64ec6c44-1b2f-4a9e-880a-1536f949eb66",
+                "createdTimestampMs": 1737748108970,
+                "updatedTimestampMs": 1743797378259,
+                "type": "attribute",
+                "key": "202",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "7cb42957-1c51-4e2e-b089-9f1a18c75f2c",
+        "createdTimestampMs": 1737748109321,
+        "updatedTimestampMs": 1743797378816,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-16",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "efbae00c-b474-4eea-82a5-52595c21e37e",
+            "createdTimestampMs": 1737748109331,
+            "updatedTimestampMs": 1743797378824,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "2f16ad39-5ca7-4641-8820-fcc53fd80da9",
+                "createdTimestampMs": 1737748109341,
+                "updatedTimestampMs": 1743797378833,
+                "type": "attribute",
+                "key": "216",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "3be7acdc-7b11-4225-a18a-c35b54593e13",
+        "createdTimestampMs": 1737748107275,
+        "updatedTimestampMs": 1743797380392,
+        "functionClass": "song-id",
+        "functionInstance": "chime",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "11c959a0-8015-48f0-9312-c9b1a6efc0cb",
+            "createdTimestampMs": 1737748107285,
+            "updatedTimestampMs": 1743797380401,
+            "name": "preset-01",
+            "deviceValues": [
+              {
+                "id": "2b760a82-320c-4210-8439-016f5096c3b7",
+                "createdTimestampMs": 1737748107295,
+                "updatedTimestampMs": 1743797380410,
+                "type": "attribute",
+                "key": "26",
+                "value": "703"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "2b1222ce-edeb-4faa-b898-1f78e0a6f90c",
+            "createdTimestampMs": 1737748107458,
+            "updatedTimestampMs": 1743797380490,
+            "name": "preset-10",
+            "deviceValues": [
+              {
+                "id": "8fdcf54a-3eb7-4966-8aa3-3e2aa7d71535",
+                "createdTimestampMs": 1737748107468,
+                "updatedTimestampMs": 1743797380500,
+                "type": "attribute",
+                "key": "26",
+                "value": "712"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "f9be52ed-0eba-4f58-b52d-792082eb7274",
+            "createdTimestampMs": 1737748107492,
+            "updatedTimestampMs": 1743797380583,
+            "name": "preset-12",
+            "deviceValues": [
+              {
+                "id": "c7414cbc-fa1b-4efd-93b9-a061db5e6481",
+                "createdTimestampMs": 1737748107502,
+                "updatedTimestampMs": 1743797380595,
+                "type": "attribute",
+                "key": "26",
+                "value": "714"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "691811c7-b55a-4674-aed0-03519ccdb72e",
+            "createdTimestampMs": 1737748107348,
+            "updatedTimestampMs": 1743797380475,
+            "name": "preset-04",
+            "deviceValues": [
+              {
+                "id": "71aeb822-88fa-4305-9a92-0df25c2b59a7",
+                "createdTimestampMs": 1737748107359,
+                "updatedTimestampMs": 1743797380484,
+                "type": "attribute",
+                "key": "26",
+                "value": "706"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "a61fff17-2cce-4150-96e6-8ea3ddd3967e",
+            "createdTimestampMs": 1737748107509,
+            "updatedTimestampMs": 1743797380416,
+            "name": "preset-13",
+            "deviceValues": [
+              {
+                "id": "c5721fa6-c859-40a7-a2b8-a6a0e8e068c9",
+                "createdTimestampMs": 1737748107520,
+                "updatedTimestampMs": 1743797380424,
+                "type": "attribute",
+                "key": "26",
+                "value": "715"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "773f2c75-fd56-4533-8577-1d4416a22d33",
+            "createdTimestampMs": 1737748107320,
+            "updatedTimestampMs": 1743797380620,
+            "name": "preset-03",
+            "deviceValues": [
+              {
+                "id": "07b306b3-622f-47e9-bce1-01b19cb704f2",
+                "createdTimestampMs": 1737748107341,
+                "updatedTimestampMs": 1743797380633,
+                "type": "attribute",
+                "key": "26",
+                "value": "705"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "a4ef2282-c37a-4efe-916c-68a607226693",
+            "createdTimestampMs": 1737748107366,
+            "updatedTimestampMs": 1743797380511,
+            "name": "preset-05",
+            "deviceValues": [
+              {
+                "id": "6aebe1c0-3129-4363-ab7d-9dead6ff0b00",
+                "createdTimestampMs": 1737748107376,
+                "updatedTimestampMs": 1743797380526,
+                "type": "attribute",
+                "key": "26",
+                "value": "707"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "d04462e9-8042-48a1-b2b6-ea2944ca0908",
+            "createdTimestampMs": 1737748107406,
+            "updatedTimestampMs": 1743797380534,
+            "name": "preset-07",
+            "deviceValues": [
+              {
+                "id": "75a4edd5-b694-416b-a106-84eab2313fa0",
+                "createdTimestampMs": 1737748107416,
+                "updatedTimestampMs": 1743797380545,
+                "type": "attribute",
+                "key": "26",
+                "value": "709"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "e7f57596-98f5-45ca-a44a-3c8beea229ca",
+            "createdTimestampMs": 1737748107383,
+            "updatedTimestampMs": 1743797380558,
+            "name": "preset-06",
+            "deviceValues": [
+              {
+                "id": "7f81ff29-747e-42a1-9f7f-a4936c738333",
+                "createdTimestampMs": 1737748107396,
+                "updatedTimestampMs": 1743797380576,
+                "type": "attribute",
+                "key": "26",
+                "value": "708"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "e8d98570-fc93-4d41-be89-1550e31cefb4",
+            "createdTimestampMs": 1737748107423,
+            "updatedTimestampMs": 1743797380431,
+            "name": "preset-08",
+            "deviceValues": [
+              {
+                "id": "1c3c5c28-e2b5-47d4-a5da-1f6495821dcd",
+                "createdTimestampMs": 1737748107434,
+                "updatedTimestampMs": 1743797380440,
+                "type": "attribute",
+                "key": "26",
+                "value": "710"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "ea74935d-5c78-4d2f-a388-fa950a7ce233",
+            "createdTimestampMs": 1737748107302,
+            "updatedTimestampMs": 1743797380446,
+            "name": "preset-02",
+            "deviceValues": [
+              {
+                "id": "b391ecf4-17b2-4baf-8dce-989ee1b3c923",
+                "createdTimestampMs": 1737748107313,
+                "updatedTimestampMs": 1743797380454,
+                "type": "attribute",
+                "key": "26",
+                "value": "704"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "f3874fb4-3ac0-4f24-b29b-4a4423f29a1a",
+            "createdTimestampMs": 1737748107475,
+            "updatedTimestampMs": 1743797380460,
+            "name": "preset-11",
+            "deviceValues": [
+              {
+                "id": "bcc1bc2c-f6ce-4458-8fc2-c57c26b621ca",
+                "createdTimestampMs": 1737748107485,
+                "updatedTimestampMs": 1743797380469,
+                "type": "attribute",
+                "key": "26",
+                "value": "713"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "5b88572f-70a2-486b-927f-03b15cd3ee05",
+            "createdTimestampMs": 1737748107441,
+            "updatedTimestampMs": 1743797380602,
+            "name": "preset-09",
+            "deviceValues": [
+              {
+                "id": "26fb607d-2a17-4601-9bbe-53f0f0eeb8cf",
+                "createdTimestampMs": 1737748107451,
+                "updatedTimestampMs": 1743797380613,
+                "type": "attribute",
+                "key": "26",
+                "value": "711"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "9219b046-b209-4e56-8ad0-71f44440ea56",
+        "createdTimestampMs": 1737748108839,
+        "updatedTimestampMs": 1743797378324,
+        "functionClass": "keyfob-config",
+        "functionInstance": "keyfob-10",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "5caf3c2b-6d88-4039-92fd-2bec13cd08ee",
+            "createdTimestampMs": 1737748108848,
+            "updatedTimestampMs": 1743797378349,
+            "name": "disabled",
+            "deviceValues": [
+              {
+                "id": "162f02a8-844f-4a59-9233-aa86b34ff058",
+                "createdTimestampMs": 1737748108858,
+                "updatedTimestampMs": 1743797378357,
+                "type": "attribute",
+                "key": "170",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "ea465756-36a8-4061-bdc2-c01370e0ef8b",
+            "createdTimestampMs": 1737748108881,
+            "updatedTimestampMs": 1743797378364,
+            "name": "delete",
+            "deviceValues": [
+              {
+                "id": "f0f66816-6a63-41d8-8d10-38fa01b265e6",
+                "createdTimestampMs": 1737748108890,
+                "updatedTimestampMs": 1743797378372,
+                "type": "attribute",
+                "key": "170",
+                "value": "2"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "4138d291-ce56-4f8e-8a77-cd798b2d9ca4",
+            "createdTimestampMs": 1737748108865,
+            "updatedTimestampMs": 1743797378332,
+            "name": "enabled",
+            "deviceValues": [
+              {
+                "id": "a8d549ed-4608-4715-b187-55ecc25d5589",
+                "createdTimestampMs": 1737748108875,
+                "updatedTimestampMs": 1743797378341,
+                "type": "attribute",
+                "key": "170",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "56b92932-feac-4745-8153-4b536a4e741a",
+        "createdTimestampMs": 1737748106354,
+        "updatedTimestampMs": 1743797380302,
+        "functionClass": "volume",
+        "functionInstance": "siren",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "76ea78ec-2b0b-4603-b76a-88427131dc86",
+            "createdTimestampMs": 1737748106399,
+            "updatedTimestampMs": 1743797380311,
+            "name": "volume-02",
+            "deviceValues": [
+              {
+                "id": "c2b4d06f-31b3-4277-b3b0-536e4053c879",
+                "createdTimestampMs": 1737748106409,
+                "updatedTimestampMs": 1743797380319,
+                "type": "attribute",
+                "key": "7",
+                "value": "20"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "daa03580-bb80-4dd1-b23b-6938e528a120",
+            "createdTimestampMs": 1737748106382,
+            "updatedTimestampMs": 1743797380359,
+            "name": "volume-01",
+            "deviceValues": [
+              {
+                "id": "1cede6c6-aa4a-481e-9027-5b024468c748",
+                "createdTimestampMs": 1737748106392,
+                "updatedTimestampMs": 1743797380369,
+                "type": "attribute",
+                "key": "7",
+                "value": "10"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "cbb90cd0-4424-40a3-a300-993e0d925c42",
+            "createdTimestampMs": 1737748106415,
+            "updatedTimestampMs": 1743797380340,
+            "name": "volume-03",
+            "deviceValues": [
+              {
+                "id": "20fdf616-e58e-46ac-9826-905a2a910ff1",
+                "createdTimestampMs": 1737748106426,
+                "updatedTimestampMs": 1743797380351,
+                "type": "attribute",
+                "key": "7",
+                "value": "30"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "fc233c0c-088e-4763-b84b-dc74274da151",
+            "createdTimestampMs": 1737748106364,
+            "updatedTimestampMs": 1743797380377,
+            "name": "volume-00",
+            "deviceValues": [
+              {
+                "id": "5bca2dcb-bc04-4ea0-9e4a-18b1f0513af6",
+                "createdTimestampMs": 1737748106374,
+                "updatedTimestampMs": 1743797380386,
+                "type": "attribute",
+                "key": "7",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "b56add82-11f7-46c9-86ad-a03f7c028f96",
+            "createdTimestampMs": 1737748106433,
+            "updatedTimestampMs": 1743797380325,
+            "name": "volume-04",
+            "deviceValues": [
+              {
+                "id": "f926694d-89e3-4acf-b498-bd1b759208c9",
+                "createdTimestampMs": 1737748106443,
+                "updatedTimestampMs": 1743797380334,
+                "type": "attribute",
+                "key": "7",
+                "value": "37"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "99430f07-f439-400f-ba1f-7c858dad0807",
+        "createdTimestampMs": 1737748110674,
+        "updatedTimestampMs": 1743797381034,
+        "functionClass": "history-event",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "90951d47-1cfb-4ab6-afde-28f0d799e11b",
+            "createdTimestampMs": 1737748110733,
+            "updatedTimestampMs": 1743797381226,
+            "name": "sensor-returned",
+            "deviceValues": [
+              {
+                "id": "6ea0e7ea-e7ab-4e8a-a7b9-1043c0434a44",
+                "createdTimestampMs": 1737748110743,
+                "updatedTimestampMs": 1743797381235,
+                "type": "attribute",
+                "key": "401",
+                "value": "4"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "f69dce27-9988-4530-9f73-a89c53802309",
+            "createdTimestampMs": 1737748110931,
+            "updatedTimestampMs": 1743797381242,
+            "name": "sensor-added-door-window",
+            "deviceValues": [
+              {
+                "id": "952b47da-584a-4c2b-8203-99c840ba9ca2",
+                "createdTimestampMs": 1737748110941,
+                "updatedTimestampMs": 1743797381253,
+                "type": "attribute",
+                "key": "401",
+                "value": "16"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "251f6a11-d28a-467e-b346-612f43529edc",
+            "createdTimestampMs": 1737748110683,
+            "updatedTimestampMs": 1743797381096,
+            "name": "sensor-triggered",
+            "deviceValues": [
+              {
+                "id": "7116b5f6-c537-45ce-a598-cee49cd14f8d",
+                "createdTimestampMs": 1737748110693,
+                "updatedTimestampMs": 1743797381106,
+                "type": "attribute",
+                "key": "401",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "0b1829d6-1074-43f5-984c-a51ca6ba26c5",
+            "createdTimestampMs": 1737748110717,
+            "updatedTimestampMs": 1743797381194,
+            "name": "sensor-missing",
+            "deviceValues": [
+              {
+                "id": "62542084-a82a-4b4d-a8d9-0559b50ee468",
+                "createdTimestampMs": 1737748110727,
+                "updatedTimestampMs": 1743797381203,
+                "type": "attribute",
+                "key": "401",
+                "value": "3"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "c61c95db-bb70-46f1-8039-4651242bb186",
+            "createdTimestampMs": 1737748110915,
+            "updatedTimestampMs": 1743797381296,
+            "name": "sensor-added-motion",
+            "deviceValues": [
+              {
+                "id": "679f906e-1cde-4bc6-ae3b-5d3bf57bf5e1",
+                "createdTimestampMs": 1737748110925,
+                "updatedTimestampMs": 1743797381306,
+                "type": "attribute",
+                "key": "401",
+                "value": "15"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "42dda574-9a82-4772-8179-0bd5d2f0b103",
+            "createdTimestampMs": 1737748110849,
+            "updatedTimestampMs": 1743797381313,
+            "name": "sensor-removed-door-window",
+            "deviceValues": [
+              {
+                "id": "caf6c80d-da79-43f9-a331-50bbada4b680",
+                "createdTimestampMs": 1737748110859,
+                "updatedTimestampMs": 1743797381324,
+                "type": "attribute",
+                "key": "401",
+                "value": "11"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "bad4e197-7e1b-4ec0-ab90-d5b398734caa",
+            "createdTimestampMs": 1737748110750,
+            "updatedTimestampMs": 1743797381178,
+            "name": "sensor-tampered",
+            "deviceValues": [
+              {
+                "id": "1892127f-f5ec-4e8d-a26e-bbd874c8c037",
+                "createdTimestampMs": 1737748110760,
+                "updatedTimestampMs": 1743797381187,
+                "type": "attribute",
+                "key": "401",
+                "value": "5"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "a2809fd8-2160-4335-8224-13650a81786b",
+            "createdTimestampMs": 1737748110865,
+            "updatedTimestampMs": 1743797381130,
+            "name": "arming-failure",
+            "deviceValues": [
+              {
+                "id": "d35c8a9e-bec9-401f-8884-5f86adff08e5",
+                "createdTimestampMs": 1737748110875,
+                "updatedTimestampMs": 1743797381139,
+                "type": "attribute",
+                "key": "401",
+                "value": "12"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "d59c69bd-c797-437c-83fd-d71b16ef7883",
+            "createdTimestampMs": 1737748110947,
+            "updatedTimestampMs": 1743797381162,
+            "name": "keyfob-added",
+            "deviceValues": [
+              {
+                "id": "8e2a4756-9885-4f8f-ba6c-c42ef7141ec7",
+                "createdTimestampMs": 1737748110957,
+                "updatedTimestampMs": 1743797381171,
+                "type": "attribute",
+                "key": "401",
+                "value": "17"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "9e3052c3-b518-4752-b731-cd6c5625fb5f",
+            "createdTimestampMs": 1737748110898,
+            "updatedTimestampMs": 1743797381077,
+            "name": "keyfob-removed",
+            "deviceValues": [
+              {
+                "id": "6ba5cccc-3792-4905-b058-a45c4b73a31e",
+                "createdTimestampMs": 1737748110908,
+                "updatedTimestampMs": 1743797381090,
+                "type": "attribute",
+                "key": "401",
+                "value": "14"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "71c05b42-4c43-4285-aad7-a2de6bde6854",
+            "createdTimestampMs": 1737748110833,
+            "updatedTimestampMs": 1743797381331,
+            "name": "sensor-removed-motion",
+            "deviceValues": [
+              {
+                "id": "91d19ffa-f59b-4f30-8b16-b0233df76b62",
+                "createdTimestampMs": 1737748110843,
+                "updatedTimestampMs": 1743797381341,
+                "type": "attribute",
+                "key": "401",
+                "value": "10"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "45a0d13f-e204-4b8f-89e0-58b703fbbcd5",
+            "createdTimestampMs": 1737748110800,
+            "updatedTimestampMs": 1743797381260,
+            "name": "sensor-valid-message",
+            "deviceValues": [
+              {
+                "id": "e1088dec-74bb-4b7e-801c-12317dbc6647",
+                "createdTimestampMs": 1737748110810,
+                "updatedTimestampMs": 1743797381271,
+                "type": "attribute",
+                "key": "401",
+                "value": "8"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "f2167ddf-14f4-49d3-bf54-99c7cc90f207",
+            "createdTimestampMs": 1737748110882,
+            "updatedTimestampMs": 1743797381145,
+            "name": "invalid-pin",
+            "deviceValues": [
+              {
+                "id": "668aaaff-8c4a-414e-9a0d-a0b6f00ba29e",
+                "createdTimestampMs": 1737748110892,
+                "updatedTimestampMs": 1743797381155,
+                "type": "attribute",
+                "key": "401",
+                "value": "13"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "df8d8666-d632-470c-9410-072afe5adad7",
+            "createdTimestampMs": 1737748110767,
+            "updatedTimestampMs": 1743797381112,
+            "name": "sensor-not-tampered",
+            "deviceValues": [
+              {
+                "id": "6bf5f6e6-ae84-49b3-8a9d-34bff9054d68",
+                "createdTimestampMs": 1737748110776,
+                "updatedTimestampMs": 1743797381121,
+                "type": "attribute",
+                "key": "401",
+                "value": "6"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "dc391738-4008-41ae-ba68-04f46f84590f",
+            "createdTimestampMs": 1737748110783,
+            "updatedTimestampMs": 1743797381278,
+            "name": "sensor-invalid-message",
+            "deviceValues": [
+              {
+                "id": "c8244b0d-9dab-498c-b9ea-cde2d3dd2502",
+                "createdTimestampMs": 1737748110793,
+                "updatedTimestampMs": 1743797381289,
+                "type": "attribute",
+                "key": "401",
+                "value": "7"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "d42239ea-bc22-4fc9-bd77-5c766d40de38",
+            "createdTimestampMs": 1737748110817,
+            "updatedTimestampMs": 1743797381210,
+            "name": "sensor-battery-report",
+            "deviceValues": [
+              {
+                "id": "73787aeb-4174-4157-878f-d7a599dd0db1",
+                "createdTimestampMs": 1737748110826,
+                "updatedTimestampMs": 1743797381219,
+                "type": "attribute",
+                "key": "401",
+                "value": "9"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "173df44a-80f0-400f-9b76-3ba319708ce6",
+            "createdTimestampMs": 1737748110700,
+            "updatedTimestampMs": 1743797381048,
+            "name": "sensor-not-triggered",
+            "deviceValues": [
+              {
+                "id": "2b818250-8c38-4112-8b94-c9f76b49f2f3",
+                "createdTimestampMs": 1737748110710,
+                "updatedTimestampMs": 1743797381064,
+                "type": "attribute",
+                "key": "401",
+                "value": "2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "f8f338ff-3199-4405-8cf3-17274bee5a56",
+        "createdTimestampMs": 1737748110143,
+        "updatedTimestampMs": 1743797380214,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-15",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "a63e3ffe-91b2-44b3-8e34-75cb9ee104f4",
+            "createdTimestampMs": 1737748110153,
+            "updatedTimestampMs": 1743797380230,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "1266bbf3-3bb0-4818-b1da-b89c81558176",
+                "createdTimestampMs": 1737748110163,
+                "updatedTimestampMs": 1743797380247,
+                "type": "attribute",
+                "key": "315",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "ad89c58e-6b44-4971-96ce-3f2107495dbe",
+        "createdTimestampMs": 1737748108084,
+        "updatedTimestampMs": 1743797380278,
+        "functionClass": "keyfob-state",
+        "functionInstance": "keyfob-3",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "dcc36c56-d7e3-425e-ba95-ab224d53b66e",
+            "createdTimestampMs": 1737748108094,
+            "updatedTimestampMs": 1743797380287,
+            "name": "keyfob-3",
+            "deviceValues": [
+              {
+                "id": "c029063d-fdb1-464a-b162-bc9250dad7a7",
+                "createdTimestampMs": 1737748108104,
+                "updatedTimestampMs": 1743797380296,
+                "type": "attribute",
+                "key": "153",
+                "format": "security-keyfob-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "bbd6d262-f05a-420d-a3e2-9e5724556afd",
+        "createdTimestampMs": 1737748110092,
+        "updatedTimestampMs": 1743797379527,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-13",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "5ae0d01a-057c-4e7b-bd82-5552e3515574",
+            "createdTimestampMs": 1737748110101,
+            "updatedTimestampMs": 1743797379545,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "b12ec13a-dfce-4f57-9499-ab08654c6adf",
+                "createdTimestampMs": 1737748110111,
+                "updatedTimestampMs": 1743797379562,
+                "type": "attribute",
+                "key": "313",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "6c5cf990-d982-425b-b7e9-940073414553",
+        "createdTimestampMs": 1737748106791,
+        "updatedTimestampMs": 1743797379978,
+        "functionClass": "volume",
+        "functionInstance": "entry-delay",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "1d8c7b4a-007e-424d-b663-c6ab6d504590",
+            "createdTimestampMs": 1737748106801,
+            "updatedTimestampMs": 1743797380035,
+            "name": "volume-00",
+            "deviceValues": [
+              {
+                "id": "3cbaf177-65ed-4f42-9a5a-963f45f1a52f",
+                "createdTimestampMs": 1737748106811,
+                "updatedTimestampMs": 1743797380044,
+                "type": "attribute",
+                "key": "22",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "fce1d84d-acec-47ea-8365-145ec25696a6",
+            "createdTimestampMs": 1737748106871,
+            "updatedTimestampMs": 1743797380002,
+            "name": "volume-04",
+            "deviceValues": [
+              {
+                "id": "f2ba816c-7ab6-4586-8802-9659e40af767",
+                "createdTimestampMs": 1737748106881,
+                "updatedTimestampMs": 1743797380012,
+                "type": "attribute",
+                "key": "22",
+                "value": "30"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "9e32971d-2ab9-469b-8f85-32ef23681de7",
+            "createdTimestampMs": 1737748106853,
+            "updatedTimestampMs": 1743797379987,
+            "name": "volume-03",
+            "deviceValues": [
+              {
+                "id": "ad07030b-1e28-4afd-b8ae-2b7bb0cf305e",
+                "createdTimestampMs": 1737748106863,
+                "updatedTimestampMs": 1743797379995,
+                "type": "attribute",
+                "key": "22",
+                "value": "15"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "075f2f35-bcc7-4b9f-89c3-08827df082bd",
+            "createdTimestampMs": 1737748106836,
+            "updatedTimestampMs": 1743797380051,
+            "name": "volume-02",
+            "deviceValues": [
+              {
+                "id": "ea447430-de61-4dc4-9ff9-f02e6b5e2473",
+                "createdTimestampMs": 1737748106846,
+                "updatedTimestampMs": 1743797380060,
+                "type": "attribute",
+                "key": "22",
+                "value": "10"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "cb745fa1-226b-407b-a52b-efaf4d3443b5",
+            "createdTimestampMs": 1737748106818,
+            "updatedTimestampMs": 1743797380019,
+            "name": "volume-01",
+            "deviceValues": [
+              {
+                "id": "d89a4f17-3681-48c8-abf8-d1c1f1ea272c",
+                "createdTimestampMs": 1737748106828,
+                "updatedTimestampMs": 1743797380029,
+                "type": "attribute",
+                "key": "22",
+                "value": "6"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "3b250b4f-08ef-4a8a-8da3-4ec852b1b86d",
+        "createdTimestampMs": 1737748109820,
+        "updatedTimestampMs": 1743797379569,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-3",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "7f84d58e-7961-43e2-b0c5-65df4176842d",
+            "createdTimestampMs": 1737748109829,
+            "updatedTimestampMs": 1743797379579,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "98b6baef-8bd2-45ec-b568-a8e7b38574c2",
+                "createdTimestampMs": 1737748109839,
+                "updatedTimestampMs": 1743797379588,
+                "type": "attribute",
+                "key": "303",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "9391fbc7-cf3f-4da4-9d62-00dc0f2a7284",
+        "createdTimestampMs": 1737748108002,
+        "updatedTimestampMs": 1743797379448,
+        "functionClass": "pin",
+        "functionInstance": "pin-10",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "874466d3-8689-41aa-9db2-eae2123e43ad",
+            "createdTimestampMs": 1737748108012,
+            "updatedTimestampMs": 1743797379458,
+            "name": "pin-10",
+            "deviceValues": [
+              {
+                "id": "0e0b5bf5-b8e8-4fc3-b79c-6eeb9c56894f",
+                "createdTimestampMs": 1737748108022,
+                "updatedTimestampMs": 1743797379466,
+                "type": "attribute",
+                "key": "110",
+                "format": "lock-pin"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "07ccec75-f791-4f07-b8e2-9dca203a0e3f",
+        "createdTimestampMs": 1737748110577,
+        "updatedTimestampMs": 1743797381009,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-31",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "911e33f6-ae26-4edb-9db1-281b5976fa08",
+            "createdTimestampMs": 1737748110587,
+            "updatedTimestampMs": 1743797381018,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "3ed7b4d9-68d2-450c-9481-7d02c1574ca9",
+                "createdTimestampMs": 1737748110598,
+                "updatedTimestampMs": 1743797381027,
+                "type": "attribute",
+                "key": "331",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "f54286e5-b96a-4012-a076-c654531e44b5",
+        "createdTimestampMs": 1737748109634,
+        "updatedTimestampMs": 1743797380192,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-28",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "f17ac860-7cda-4ed1-94d6-a935d51d086e",
+            "createdTimestampMs": 1737748109644,
+            "updatedTimestampMs": 1743797380200,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "d2d0d20a-5472-4d65-9d62-cd23dff47807",
+                "createdTimestampMs": 1737748109653,
+                "updatedTimestampMs": 1743797380208,
+                "type": "attribute",
+                "key": "228",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "5b3fdca1-f716-4d0a-beb5-a8af09b5e616",
+        "createdTimestampMs": 1737748110964,
+        "updatedTimestampMs": 1743797382238,
+        "functionClass": "disarmed-by",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "85ebd9a3-622e-4d4d-86ee-0374b5f014ef",
+            "createdTimestampMs": 1737748110990,
+            "updatedTimestampMs": 1743797382376,
+            "name": "pin-2",
+            "deviceValues": [
+              {
+                "id": "78b06c8e-7612-4e2d-a513-b4c5e6ccea2c",
+                "createdTimestampMs": 1737748111000,
+                "updatedTimestampMs": 1743797382385,
+                "type": "attribute",
+                "key": "402",
+                "value": "2"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "9ef9a797-cad1-455b-896a-c301d6cfbffc",
+            "createdTimestampMs": 1737748111091,
+            "updatedTimestampMs": 1743797382290,
+            "name": "pin-8",
+            "deviceValues": [
+              {
+                "id": "4646e1b5-2356-4bd1-a899-3c8d86f69067",
+                "createdTimestampMs": 1737748111101,
+                "updatedTimestampMs": 1743797382298,
+                "type": "attribute",
+                "key": "402",
+                "value": "8"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "e10705c9-aa44-4565-a522-178b42eef1a3",
+            "createdTimestampMs": 1737748111023,
+            "updatedTimestampMs": 1743797382319,
+            "name": "pin-4",
+            "deviceValues": [
+              {
+                "id": "57878fa7-ad68-4ff5-84c7-284ac56ec135",
+                "createdTimestampMs": 1737748111033,
+                "updatedTimestampMs": 1743797382327,
+                "type": "attribute",
+                "key": "402",
+                "value": "4"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "7f560274-a2f3-4f05-af2b-2a48b795a726",
+            "createdTimestampMs": 1737748111107,
+            "updatedTimestampMs": 1743797382275,
+            "name": "pin-9",
+            "deviceValues": [
+              {
+                "id": "282fc90d-128c-4854-8810-8b1f58e172aa",
+                "createdTimestampMs": 1737748111118,
+                "updatedTimestampMs": 1743797382284,
+                "type": "attribute",
+                "key": "402",
+                "value": "9"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "898321e3-7a49-4170-a83d-96ab597aa7f8",
+            "createdTimestampMs": 1737748111124,
+            "updatedTimestampMs": 1743797382363,
+            "name": "pin-10",
+            "deviceValues": [
+              {
+                "id": "41f0ac83-41fd-4f7b-bfcd-b182e9733ce4",
+                "createdTimestampMs": 1737748111134,
+                "updatedTimestampMs": 1743797382371,
+                "type": "attribute",
+                "key": "402",
+                "value": "10"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "a489b4e4-e912-4b57-a124-247f7c886f2c",
+            "createdTimestampMs": 1737748111007,
+            "updatedTimestampMs": 1743797382305,
+            "name": "pin-3",
+            "deviceValues": [
+              {
+                "id": "344d491b-8806-4141-8e48-5954f166e4dc",
+                "createdTimestampMs": 1737748111017,
+                "updatedTimestampMs": 1743797382313,
+                "type": "attribute",
+                "key": "402",
+                "value": "3"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "2b4a38e5-1542-4418-bc7b-2be9418823a8",
+            "createdTimestampMs": 1737748111058,
+            "updatedTimestampMs": 1743797382333,
+            "name": "pin-6",
+            "deviceValues": [
+              {
+                "id": "53bad1f4-7498-46e6-b569-47d7d631cb53",
+                "createdTimestampMs": 1737748111068,
+                "updatedTimestampMs": 1743797382342,
+                "type": "attribute",
+                "key": "402",
+                "value": "6"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "b5571f4e-a58a-480a-80d0-e73132bbb2d5",
+            "createdTimestampMs": 1737748111041,
+            "updatedTimestampMs": 1743797382349,
+            "name": "pin-5",
+            "deviceValues": [
+              {
+                "id": "b8cd3921-22ef-4dad-977a-e9ec90bd3bbc",
+                "createdTimestampMs": 1737748111051,
+                "updatedTimestampMs": 1743797382358,
+                "type": "attribute",
+                "key": "402",
+                "value": "5"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "3640beb2-b313-48d8-a9eb-1a3519d5667f",
+            "createdTimestampMs": 1737748110973,
+            "updatedTimestampMs": 1743797382260,
+            "name": "pin-1",
+            "deviceValues": [
+              {
+                "id": "a203dd9a-5857-44f1-91c0-c0da0d4b0d8a",
+                "createdTimestampMs": 1737748110984,
+                "updatedTimestampMs": 1743797382269,
+                "type": "attribute",
+                "key": "402",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "0b536cc7-6ed3-40d3-82b6-fcc5c0c5ae94",
+            "createdTimestampMs": 1737748111075,
+            "updatedTimestampMs": 1743797382246,
+            "name": "pin-7",
+            "deviceValues": [
+              {
+                "id": "885841b8-a3d0-4fe1-9a6a-70082d8a1354",
+                "createdTimestampMs": 1737748111085,
+                "updatedTimestampMs": 1743797382254,
+                "type": "attribute",
+                "key": "402",
+                "value": "7"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "19af8981-c384-4c82-a3d6-36e6a0229f5f",
+        "createdTimestampMs": 1737748110631,
+        "updatedTimestampMs": 1743797378418,
+        "functionClass": "battery-powered",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "deb39acc-2d63-4457-a5a8-88cd652bab61",
+            "createdTimestampMs": 1737748110657,
+            "updatedTimestampMs": 1743797378427,
+            "name": "battery-powered",
+            "deviceValues": [
+              {
+                "id": "59b6b4be-e74b-4b9b-9ace-d15f201bcc38",
+                "createdTimestampMs": 1737748110667,
+                "updatedTimestampMs": 1743797378435,
+                "type": "attribute",
+                "key": "400",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "904d13d1-d315-49d8-b3f9-09b1efa602c5",
+            "createdTimestampMs": 1737748110641,
+            "updatedTimestampMs": 1743797378441,
+            "name": "wall-powered",
+            "deviceValues": [
+              {
+                "id": "9085a6ee-84ac-4da0-b0a5-dbf9ac74e8f1",
+                "createdTimestampMs": 1737748110651,
+                "updatedTimestampMs": 1743797378451,
+                "type": "attribute",
+                "key": "400",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "c8cacb8a-d2a8-4e40-9b0b-cefcc99e4ce7",
+        "createdTimestampMs": 1737748106494,
+        "updatedTimestampMs": 1743797380943,
+        "functionClass": "siren-action",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "2c95eddf-42cd-4e21-ae7a-3fe7772e38e6",
+            "createdTimestampMs": 1737748106504,
+            "updatedTimestampMs": 1743797380952,
+            "name": "siren-action",
+            "deviceValues": [
+              {
+                "id": "80982828-3389-4592-b1c0-7ce7ebf4186d",
+                "createdTimestampMs": 1737748106514,
+                "updatedTimestampMs": 1743797380967,
+                "type": "attribute",
+                "key": "10",
+                "format": "security-siren-action"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "3b5072d3-c942-49b0-9a27-5d6a1ae20d2f",
+        "createdTimestampMs": 1737748108716,
+        "updatedTimestampMs": 1743797380135,
+        "functionClass": "keyfob-config",
+        "functionInstance": "keyfob-8",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "6f72ce67-8323-44d8-adab-36aaa45ae4cc",
+            "createdTimestampMs": 1737748108725,
+            "updatedTimestampMs": 1743797380144,
+            "name": "disabled",
+            "deviceValues": [
+              {
+                "id": "bacc4e14-570d-4268-ade9-394ca7884dbb",
+                "createdTimestampMs": 1737748108735,
+                "updatedTimestampMs": 1743797380156,
+                "type": "attribute",
+                "key": "168",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "7a7a76a2-00e0-4db0-80b5-24dbe0029dbc",
+            "createdTimestampMs": 1737748108758,
+            "updatedTimestampMs": 1743797380163,
+            "name": "delete",
+            "deviceValues": [
+              {
+                "id": "e65c2226-3956-4f7a-ae36-4521ddc9efb9",
+                "createdTimestampMs": 1737748108769,
+                "updatedTimestampMs": 1743797380171,
+                "type": "attribute",
+                "key": "168",
+                "value": "2"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "e76db98e-7d35-4aa3-9759-d21f612ce5e1",
+            "createdTimestampMs": 1737748108741,
+            "updatedTimestampMs": 1743797380177,
+            "name": "enabled",
+            "deviceValues": [
+              {
+                "id": "9677a0c4-c742-45d3-8a44-21fc764e288b",
+                "createdTimestampMs": 1737748108752,
+                "updatedTimestampMs": 1743797380186,
+                "type": "attribute",
+                "key": "168",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "b1009473-d645-438e-bac5-49045840b72e",
+        "createdTimestampMs": 1737748107841,
+        "updatedTimestampMs": 1743797378481,
+        "functionClass": "pin",
+        "functionInstance": "pin-4",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "b60644a2-bd84-4972-8053-8a2fe4498143",
+            "createdTimestampMs": 1737748107852,
+            "updatedTimestampMs": 1743797378490,
+            "name": "pin-4",
+            "deviceValues": [
+              {
+                "id": "83a7a43d-6a64-44f1-a5b8-e359b30ced17",
+                "createdTimestampMs": 1737748107862,
+                "updatedTimestampMs": 1743797378499,
+                "type": "attribute",
+                "key": "104",
+                "format": "lock-pin"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "4bdfa7c0-1b01-4a3a-a4c0-341762f7bc9b",
+        "createdTimestampMs": 1737748109003,
+        "updatedTimestampMs": 1743797382391,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-4",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "0733bfc5-f749-41ba-ad6c-d2b933f1d6c8",
+            "createdTimestampMs": 1737748109013,
+            "updatedTimestampMs": 1743797382399,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "bf22481d-df18-4ec0-994e-2ef9590ece8e",
+                "createdTimestampMs": 1737748109023,
+                "updatedTimestampMs": 1743797382407,
+                "type": "attribute",
+                "key": "204",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "d26cb3d2-fec4-406e-a75e-2a2a69447179",
+        "createdTimestampMs": 1737748110549,
+        "updatedTimestampMs": 1743797381963,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-30",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "07c7d26e-2131-48fa-a7fb-d142cc5d8e02",
+            "createdTimestampMs": 1737748110560,
+            "updatedTimestampMs": 1743797381973,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "55d6bcf9-fa5e-45b5-846f-4a95b0546e53",
+                "createdTimestampMs": 1737748110570,
+                "updatedTimestampMs": 1743797381984,
+                "type": "attribute",
+                "key": "330",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "eb606390-db53-49a3-bd23-bae7207ab848",
+        "createdTimestampMs": 1737748109082,
+        "updatedTimestampMs": 1743797379703,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-7",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "20ccfed3-82a3-4437-91ea-ad56e6769a63",
+            "createdTimestampMs": 1737748109092,
+            "updatedTimestampMs": 1743797379714,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "fda64b87-1651-4313-8e3d-64bf6fc3ad6d",
+                "createdTimestampMs": 1737748109101,
+                "updatedTimestampMs": 1743797379725,
+                "type": "attribute",
+                "key": "207",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "f3b4cfc2-7bf5-4167-9a36-7e8c46dc6b7b",
+        "createdTimestampMs": 1737748109979,
+        "updatedTimestampMs": 1743797378795,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-9",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "4225e7e5-a3e7-482a-beab-b446a26a72c2",
+            "createdTimestampMs": 1737748109988,
+            "updatedTimestampMs": 1743797378803,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "cdc71bb6-2a67-40b2-8cec-7612f3570fd9",
+                "createdTimestampMs": 1737748109998,
+                "updatedTimestampMs": 1743797378811,
+                "type": "attribute",
+                "key": "309",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "28b136a5-9832-4fad-bf5c-8bce68e08709",
+        "createdTimestampMs": 1737748109108,
+        "updatedTimestampMs": 1743797381453,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-8",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "ef8db39a-155e-4edb-97c6-ea004537e060",
+            "createdTimestampMs": 1737748109117,
+            "updatedTimestampMs": 1743797381462,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "fff2c727-d49e-43d9-a28b-c9da1afe1d9b",
+                "createdTimestampMs": 1737748109127,
+                "updatedTimestampMs": 1743797381471,
+                "type": "attribute",
+                "key": "208",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "add9d377-2886-4e7d-b0b1-452da7e262e1",
+        "createdTimestampMs": 1737748110280,
+        "updatedTimestampMs": 1743797381477,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-20",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "27b3873d-1d58-4404-9d30-3a2c9bc1c7fe",
+            "createdTimestampMs": 1737748110290,
+            "updatedTimestampMs": 1743797381486,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "2d373f0b-0027-4ebd-bd7a-341e4eddd659",
+                "createdTimestampMs": 1737748110300,
+                "updatedTimestampMs": 1743797381496,
+                "type": "attribute",
+                "key": "320",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "dec0e1d0-df74-4e2e-9962-10918c72d5b1",
+        "createdTimestampMs": 1737748106309,
+        "updatedTimestampMs": 1743797378379,
+        "functionClass": "bypass-allowed",
+        "type": "category",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "0724c7c6-960e-4554-bc24-137971a3e81f",
+            "createdTimestampMs": 1737748106337,
+            "updatedTimestampMs": 1743797378388,
+            "name": "allowed",
+            "deviceValues": [
+              {
+                "id": "15de8981-a661-44a9-94ee-67a512f55cdb",
+                "createdTimestampMs": 1737748106347,
+                "updatedTimestampMs": 1743797378397,
+                "type": "attribute",
+                "key": "6",
+                "value": "1"
+              }
+            ],
+            "range": {}
+          },
+          {
+            "id": "b868bc15-59ab-46a2-a865-43dddd1c8292",
+            "createdTimestampMs": 1737748106319,
+            "updatedTimestampMs": 1743797378403,
+            "name": "now-allowed",
+            "deviceValues": [
+              {
+                "id": "122ecd52-9f2c-4d87-a432-62cf42f2bdd2",
+                "createdTimestampMs": 1737748106330,
+                "updatedTimestampMs": 1743797378412,
+                "type": "attribute",
+                "key": "6",
+                "value": "0"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "c0a2a7b0-5a02-4e1f-a6c7-6285f9c07071",
+        "createdTimestampMs": 1737748108165,
+        "updatedTimestampMs": 1743797380829,
+        "functionClass": "keyfob-state",
+        "functionInstance": "keyfob-6",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "e83a9387-661d-4463-8929-0b5248c3e50a",
+            "createdTimestampMs": 1737748108174,
+            "updatedTimestampMs": 1743797380837,
+            "name": "keyfob-6",
+            "deviceValues": [
+              {
+                "id": "f5da80fc-951e-4c76-bc0e-8687b3aa7359",
+                "createdTimestampMs": 1737748108184,
+                "updatedTimestampMs": 1743797380858,
+                "type": "attribute",
+                "key": "156",
+                "format": "security-keyfob-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "76b699f1-6390-4f67-8f59-c17ca30555cd",
+        "createdTimestampMs": 1737748109740,
+        "updatedTimestampMs": 1743797379339,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-32",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "3375f9cd-2361-49ea-af8b-68f6db4dcc9d",
+            "createdTimestampMs": 1737748109750,
+            "updatedTimestampMs": 1743797379359,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "34b484f2-737a-4d88-80ec-f36ccfdef04a",
+                "createdTimestampMs": 1737748109760,
+                "updatedTimestampMs": 1743797379371,
+                "type": "attribute",
+                "key": "232",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "5c4b604e-c8e6-491b-ada1-e0ef263a5f96",
+        "createdTimestampMs": 1737748110442,
+        "updatedTimestampMs": 1743797377927,
+        "functionClass": "sensor-config",
+        "functionInstance": "sensor-26",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "096697fe-d9ef-4beb-9bc7-0fea678bf439",
+            "createdTimestampMs": 1737748110451,
+            "updatedTimestampMs": 1743797377950,
+            "name": "sensor-config",
+            "deviceValues": [
+              {
+                "id": "cea2550a-38d7-477a-9db6-5340118fce56",
+                "createdTimestampMs": 1737748110461,
+                "updatedTimestampMs": 1743797377965,
+                "type": "attribute",
+                "key": "326",
+                "format": "security-sensor-config-v2"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      },
+      {
+        "id": "6b5284b8-9e01-4a61-862c-875f1c285428",
+        "createdTimestampMs": 1737748109451,
+        "updatedTimestampMs": 1743797381530,
+        "functionClass": "sensor-state",
+        "functionInstance": "sensor-21",
+        "type": "object",
+        "schedulable": false,
+        "values": [
+          {
+            "id": "bda8d699-13b3-4304-b0eb-0d0cc3aba4f0",
+            "createdTimestampMs": 1737748109461,
+            "updatedTimestampMs": 1743797381539,
+            "name": "sensor-state",
+            "deviceValues": [
+              {
+                "id": "b94971f1-1571-4855-8029-15a8fe2f2c7b",
+                "createdTimestampMs": 1737748109471,
+                "updatedTimestampMs": 1743797381549,
+                "type": "attribute",
+                "key": "221",
+                "format": "security-sensor-state"
+              }
+            ],
+            "range": {}
+          }
+        ]
+      }
+    ],
+    "states": [
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-18"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-19"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-12"
+      },
+      {
+        "functionClass": "song-id",
+        "value": "preset-01",
+        "lastUpdateTime": 0,
+        "functionInstance": "alarm"
+      },
+      {
+        "functionClass": "pin",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "pin-7"
+      },
+      {
+        "functionClass": "volume",
+        "value": "volume-01",
+        "lastUpdateTime": 0,
+        "functionInstance": "exit-delay-stay"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-26"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-14"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-12"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-10"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-7"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-17"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": {
+          "security-sensor-config-v2": {
+            "chirpMode": 0,
+            "triggerType": 3,
+            "bypassType": 0
+          }
+        },
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-2"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-10"
+      },
+      {
+        "functionClass": "pin",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "pin-5"
+      },
+      {
+        "functionClass": "pin",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "pin-8"
+      },
+      {
+        "functionClass": "pin",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "pin-6"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-27"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-25"
+      },
+      {
+        "functionClass": "song-id",
+        "value": "preset-01",
+        "lastUpdateTime": 0,
+        "functionInstance": "beep"
+      },
+      {
+        "functionClass": "arm-exit-delay",
+        "value": 30,
+        "lastUpdateTime": 0,
+        "functionInstance": "away"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-19"
+      },
+      {
+        "functionClass": "keyfob-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "keyfob-8"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-18"
+      },
+      {
+        "functionClass": "siren-alarm-timeout",
+        "value": 180,
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "volume",
+        "value": "volume-01",
+        "lastUpdateTime": 0,
+        "functionInstance": "chime"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-6"
+      },
+      {
+        "functionClass": "keyfob-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "keyfob-5"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-6"
+      },
+      {
+        "functionClass": "battery-level",
+        "value": 5,
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "keyfob-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "keyfob-4"
+      },
+      {
+        "functionClass": "arm-exit-delay",
+        "value": 0,
+        "lastUpdateTime": 0,
+        "functionInstance": "stay"
+      },
+      {
+        "functionClass": "dark-mode",
+        "value": "off",
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "pin",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "pin-3"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-27"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-22"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-13"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-5"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-25"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-11"
+      },
+      {
+        "functionClass": "keyfob-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "keyfob-7"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": {
+          "security-sensor-config-v2": {
+            "chirpMode": 1,
+            "triggerType": 3,
+            "bypassType": 0
+          }
+        },
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-4"
+      },
+      {
+        "functionClass": "pin",
+        "value": {
+          "lock-pin": {
+            "pin": "",
+            "active": true,
+            "type": 0
+          }
+        },
+        "lastUpdateTime": 0,
+        "functionInstance": "pin-1"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-23"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-5"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-29"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-3"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-32"
+      },
+      {
+        "functionClass": "pin",
+        "value": {
+          "lock-pin": {
+            "pin": "",
+            "active": true,
+            "type": 0
+          }
+        },
+        "lastUpdateTime": 0,
+        "functionInstance": "pin-2"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-17"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-22"
+      },
+      {
+        "functionClass": "keypad-device-id",
+        "value": "01232720699144fa",
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-11"
+      },
+      {
+        "functionClass": "keyfob-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "keyfob-1"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-31"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-28"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-8"
+      },
+      {
+        "functionClass": "volume",
+        "value": "volume-01",
+        "lastUpdateTime": 0,
+        "functionInstance": "exit-delay-away"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-16"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-21"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-23"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": {
+          "security-sensor-config-v2": {
+            "chirpMode": 0,
+            "triggerType": 3,
+            "bypassType": 0
+          }
+        },
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-1"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": {
+          "security-sensor-state": {
+            "deviceType": 2,
+            "tampered": 0,
+            "triggered": 0,
+            "missing": 0,
+            "versionBuild": 3,
+            "versionMajor": 2,
+            "versionMinor": 0,
+            "batteryLevel": 100
+          }
+        },
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-1"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-24"
+      },
+      {
+        "functionClass": "pin",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "pin-9"
+      },
+      {
+        "functionClass": "temporary-bypass-time",
+        "value": 60,
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-9"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-24"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-15"
+      },
+      {
+        "functionClass": "keyfob-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "keyfob-10"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-14"
+      },
+      {
+        "functionClass": "alarm-state",
+        "value": "disarmed",
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-29"
+      },
+      {
+        "functionClass": "keyfob-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "keyfob-9"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-20"
+      },
+      {
+        "functionClass": "keyfob-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "keyfob-2"
+      },
+      {
+        "functionClass": "disarm-entry-delay",
+        "value": 60,
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-30"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": {
+          "security-sensor-state": {
+            "deviceType": 2,
+            "tampered": 0,
+            "triggered": 1,
+            "missing": 0,
+            "versionBuild": 3,
+            "versionMajor": 2,
+            "versionMinor": 0,
+            "batteryLevel": 100
+          }
+        },
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-2"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-16"
+      },
+      {
+        "functionClass": "song-id",
+        "value": "preset-02",
+        "lastUpdateTime": 0,
+        "functionInstance": "chime"
+      },
+      {
+        "functionClass": "volume",
+        "value": "volume-04",
+        "lastUpdateTime": 0,
+        "functionInstance": "siren"
+      },
+      {
+        "functionClass": "history-event",
+        "value": "sensor-triggered",
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-15"
+      },
+      {
+        "functionClass": "keyfob-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "keyfob-3"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-13"
+      },
+      {
+        "functionClass": "volume",
+        "value": "volume-01",
+        "lastUpdateTime": 0,
+        "functionInstance": "entry-delay"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-3"
+      },
+      {
+        "functionClass": "pin",
+        "value": {
+          "lock-pin": {
+            "pin": "",
+            "active": true,
+            "type": 0
+          }
+        },
+        "lastUpdateTime": 0,
+        "functionInstance": "pin-10"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-31"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-28"
+      },
+      {
+        "functionClass": "disarmed-by",
+        "value": "pin-1",
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "battery-powered",
+        "value": "wall-powered",
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "siren-action",
+        "value": {
+          "security-siren-action": {
+            "resultCode": 0,
+            "command": 4
+          }
+        },
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "pin",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "pin-4"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": {
+          "security-sensor-state": {
+            "deviceType": 2,
+            "tampered": 0,
+            "triggered": 0,
+            "missing": 0,
+            "versionBuild": 3,
+            "versionMajor": 2,
+            "versionMinor": 0,
+            "batteryLevel": 100
+          }
+        },
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-4"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-30"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-7"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-9"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-8"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-20"
+      },
+      {
+        "functionClass": "bypass-allowed",
+        "value": "now-allowed",
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "keyfob-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "keyfob-6"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-32"
+      },
+      {
+        "functionClass": "sensor-config",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-26"
+      },
+      {
+        "functionClass": "sensor-state",
+        "value": null,
+        "lastUpdateTime": 0,
+        "functionInstance": "sensor-21"
+      },
+      {
+        "functionClass": "wifi-ssid",
+        "value": "a9d5e65c-a7b9-46ca-a025-413d223d708e",
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "wifi-rssi",
+        "value": -34,
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "wifi-steady-state",
+        "value": "connected",
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "wifi-setup-state",
+        "value": "connected",
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "wifi-mac-address",
+        "value": "f2322f40-7f0c-4474-ae0a-c0844e998a7a",
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "geo-coordinates",
+        "value": {
+          "geo-coordinates": {
+            "latitude": "0",
+            "longitude": "0"
+          }
+        },
+        "lastUpdateTime": 0,
+        "functionInstance": "system-device-location"
+      },
+      {
+        "functionClass": "scheduler-flags",
+        "value": 0,
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "available",
+        "value": true,
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "visible",
+        "value": true,
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "direct",
+        "value": true,
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      },
+      {
+        "functionClass": "ble-mac-address",
+        "value": "522b6cda-33a0-46a5-8c53-5c53447c95c0",
+        "lastUpdateTime": 0,
+        "functionInstance": null
+      }
+    ],
+    "children": [],
+    "manufacturerName": "Defiant"
+  }
+]

--- a/tests/test_alarm_control_panel.py
+++ b/tests/test_alarm_control_panel.py
@@ -1,0 +1,259 @@
+"""Test the integration between Home Assistant Switches and Afero devices."""
+
+from aioafero import AferoState
+from homeassistant.components.alarm_control_panel import (
+    AlarmControlPanelEntityFeature,
+    AlarmControlPanelState,
+    CodeFormat,
+)
+from homeassistant.helpers import entity_registry as er
+import pytest
+
+from .utils import create_devices_from_data, hs_raw_from_dump, modify_state
+
+alarm_panel = create_devices_from_data("security-system.json")[1]
+alarm_panel_id = "alarm_control_panel.helms_deep_securitysystem"
+
+
+@pytest.fixture
+async def mocked_entity(mocked_entry):
+    """Initialize a mocked Alarm Panel and register it within Home Assistant."""
+    hass, entry, bridge = mocked_entry
+    # Register callbacks
+    await hass.config_entries.async_setup(entry.entry_id)
+    # Now generate update event by emitting the json we've sent as incoming event
+    afero_data = hs_raw_from_dump("security-system.json")
+    await bridge.generate_events_from_data(afero_data)
+    await bridge.async_block_until_done()
+    await hass.async_block_till_done()
+    return mocked_entry
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry(mocked_entity):
+    """Ensure switches are properly discovered and registered with Home Assistant."""
+    hass, entry, bridge = mocked_entity
+    entity_reg = er.async_get(hass)
+    assert entity_reg.async_get(alarm_panel_id) is not None
+    entity = hass.states.get(alarm_panel_id)
+    assert entity.state == AlarmControlPanelState.DISARMED
+    assert entity.attributes["code_format"] == CodeFormat.NUMBER
+    assert entity.attributes["code_arm_required"] is False
+    expected = (
+        AlarmControlPanelEntityFeature.ARM_AWAY
+        + AlarmControlPanelEntityFeature.ARM_HOME
+        + AlarmControlPanelEntityFeature.TRIGGER
+    )
+    assert entity.attributes["supported_features"] == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("panel_state", "expected"),
+    [
+        ("arm-away", AlarmControlPanelState.ARMED_AWAY),
+        ("alarming", AlarmControlPanelState.TRIGGERED),
+        ("alarming-sos", AlarmControlPanelState.TRIGGERED),
+        ("arm-stay", AlarmControlPanelState.ARMED_HOME),
+        ("arm-started-stay", AlarmControlPanelState.ARMING),
+        ("disarmed", AlarmControlPanelState.DISARMED),
+        ("triggered", AlarmControlPanelState.PENDING),
+        ("arm-started-away", AlarmControlPanelState.ARMING),
+    ],
+)
+async def test_alarm_state(panel_state, expected, mocked_entity):
+    """Ensure a proper mapping between Hubspace and Home Assistant."""
+    hass, entry, bridge = mocked_entity
+    alarm_panel = create_devices_from_data("security-system.json")[1]
+    modify_state(
+        alarm_panel,
+        AferoState(
+            functionClass="alarm-state",
+            functionInstance=None,
+            value=panel_state,
+        ),
+    )
+
+    event = {
+        "type": "update",
+        "device_id": alarm_panel.id,
+        "device": alarm_panel,
+    }
+    bridge.emit_event("update", event)
+    await hass.async_block_till_done()
+    entity = hass.states.get(alarm_panel_id)
+    assert entity is not None
+    assert entity.state == expected
+
+
+@pytest.mark.asyncio
+async def test_add_new_device(mocked_entity):
+    """Ensure newly added devices are properly discovered and registered with Home Assistant."""
+    hass, _, _ = mocked_entity
+    entity_reg = er.async_get(hass)
+    assert entity_reg.async_get(alarm_panel_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_service_alarm_disarm(mocked_entity):
+    """Ensure the service call turn_on works as expected."""
+    hass, _, bridge = mocked_entity
+    expected_state = "disarmed"
+    bridge.security_systems[alarm_panel.id].alarm_state.mode = "armed-away"
+    await hass.services.async_call(
+        "alarm_control_panel",
+        "alarm_disarm",
+        {"entity_id": alarm_panel_id},
+        blocking=True,
+    )
+    update_call = bridge.request.call_args_list[-1]
+    assert update_call.args[0] == "put"
+    payload = update_call.kwargs["json"]
+    assert payload["metadeviceId"] == alarm_panel.id
+    update = payload["values"][0]
+    assert update["functionClass"] == "alarm-state"
+    assert update["functionInstance"] is None
+    assert update["value"] == expected_state
+    # Now generate update event by emitting the json we've sent as incoming event
+    entity_update = create_devices_from_data("security-system.json")[1]
+    modify_state(
+        alarm_panel,
+        AferoState(
+            functionClass="alarm-state",
+            functionInstance=None,
+            value=expected_state,
+        ),
+    )
+    event = {
+        "type": "update",
+        "device_id": alarm_panel.id,
+        "device": entity_update,
+    }
+    bridge.emit_event("update", event)
+    await hass.async_block_till_done()
+    entity = hass.states.get(alarm_panel_id)
+    assert entity is not None
+    assert entity.state == AlarmControlPanelState.DISARMED
+
+
+@pytest.mark.asyncio
+async def test_service_alarm_arm_home(mocked_entity):
+    """Ensure the service call turn_on works as expected."""
+    hass, _, bridge = mocked_entity
+    expected_state = "arm-started-stay"
+    await hass.services.async_call(
+        "alarm_control_panel",
+        "alarm_arm_home",
+        {"entity_id": alarm_panel_id},
+        blocking=True,
+    )
+    update_call = bridge.request.call_args_list[-1]
+    assert update_call.args[0] == "put"
+    payload = update_call.kwargs["json"]
+    assert payload["metadeviceId"] == alarm_panel.id
+    update = payload["values"][0]
+    assert update["functionClass"] == "alarm-state"
+    assert update["functionInstance"] is None
+    assert update["value"] == expected_state
+    # Now generate update event by emitting the json we've sent as incoming event
+    entity_update = create_devices_from_data("security-system.json")[1]
+    modify_state(
+        entity_update,
+        AferoState(
+            functionClass="alarm-state",
+            functionInstance=None,
+            value=expected_state,
+        ),
+    )
+    event = {
+        "type": "update",
+        "device_id": alarm_panel.id,
+        "device": entity_update,
+    }
+    bridge.emit_event("update", event)
+    await hass.async_block_till_done()
+    entity = hass.states.get(alarm_panel_id)
+    assert entity is not None
+    assert entity.state == AlarmControlPanelState.ARMING
+
+
+@pytest.mark.asyncio
+async def test_service_alarm_arm_away(mocked_entity):
+    """Ensure the service call turn_on works as expected."""
+    hass, _, bridge = mocked_entity
+    expected_state = "arm-started-away"
+    await hass.services.async_call(
+        "alarm_control_panel",
+        "alarm_arm_away",
+        {"entity_id": alarm_panel_id},
+        blocking=True,
+    )
+    update_call = bridge.request.call_args_list[-1]
+    assert update_call.args[0] == "put"
+    payload = update_call.kwargs["json"]
+    assert payload["metadeviceId"] == alarm_panel.id
+    update = payload["values"][0]
+    assert update["functionClass"] == "alarm-state"
+    assert update["functionInstance"] is None
+    assert update["value"] == expected_state
+    # Now generate update event by emitting the json we've sent as incoming event
+    entity_update = create_devices_from_data("security-system.json")[1]
+    modify_state(
+        entity_update,
+        AferoState(
+            functionClass="alarm-state",
+            functionInstance=None,
+            value=expected_state,
+        ),
+    )
+    event = {
+        "type": "update",
+        "device_id": alarm_panel.id,
+        "device": entity_update,
+    }
+    bridge.emit_event("update", event)
+    await hass.async_block_till_done()
+    entity = hass.states.get(alarm_panel_id)
+    assert entity is not None
+    assert entity.state == AlarmControlPanelState.ARMING
+
+
+@pytest.mark.asyncio
+async def test_service_alarm_trigger(mocked_entity):
+    """Ensure the service call turn_on works as expected."""
+    hass, _, bridge = mocked_entity
+    expected_state = "alarming-sos"
+    await hass.services.async_call(
+        "alarm_control_panel",
+        "alarm_trigger",
+        {"entity_id": alarm_panel_id},
+        blocking=True,
+    )
+    update_call = bridge.request.call_args_list[-1]
+    assert update_call.args[0] == "put"
+    payload = update_call.kwargs["json"]
+    assert payload["metadeviceId"] == alarm_panel.id
+    update = payload["values"][0]
+    assert update["functionClass"] == "alarm-state"
+    assert update["functionInstance"] is None
+    assert update["value"] == expected_state
+    # Now generate update event by emitting the json we've sent as incoming event
+    entity_update = create_devices_from_data("security-system.json")[1]
+    modify_state(
+        entity_update,
+        AferoState(
+            functionClass="alarm-state",
+            functionInstance=None,
+            value=expected_state,
+        ),
+    )
+    event = {
+        "type": "update",
+        "device_id": alarm_panel.id,
+        "device": entity_update,
+    }
+    bridge.emit_event("update", event)
+    await hass.async_block_till_done()
+    entity = hass.states.get(alarm_panel_id)
+    assert entity is not None
+    assert entity.state == AlarmControlPanelState.TRIGGERED

--- a/tests/test_alarm_control_panel.py
+++ b/tests/test_alarm_control_panel.py
@@ -80,6 +80,7 @@ async def test_alarm_state(panel_state, expected, mocked_entity):
         "device": alarm_panel,
     }
     bridge.emit_event("update", event)
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(alarm_panel_id)
     assert entity is not None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -45,7 +45,7 @@ def create_devices_from_data(file_name: str) -> list[AferoDevice]:
 
 
 def hs_raw_from_dump(file_name: str) -> list[dict]:
-    """Generate a Hubspace payload from devices and save it to a file.
+    """Generate a Hubspace payload from devices.
 
     Takes a device dump file and process into a "raw" Afero format. This
     enables one dump for testing raw and processed sides.
@@ -91,6 +91,46 @@ def hs_raw_from_dump(file_name: str) -> list[dict]:
             }
         )
     return hs_raw
+
+
+def hs_raw_from_device(device: AferoDevice) -> dict:
+    """Generate a Hubspace payload from an AferoDevice.
+
+    :param device: Device to convert to a raw dump
+    """
+    descr_device = {
+        "defaultName": device.default_name,
+        "deviceClass": device.device_class,
+        "manufacturerName": device.manufacturerName,
+        "model": device.model,
+        "profileId": "6ea6d241-3909-4235-836d-c594ece2bb67",
+        "type": "device",
+    }
+    description = {
+        "createdTimestampMs": 0,
+        "defaultImage": device.default_image,
+        "descriptions": [],
+        "device": descr_device,
+        "functions": device.functions,
+        "hints": [],
+        "id": device.id,
+        "updatedTimestampMs": 0,
+        "version": 1,
+    }
+    return {
+        "children": device.children,
+        "createdTimestampMs": 0,
+        "description": description,
+        "deviceId": device.device_id,
+        "friendlyDescription": "",
+        "friendlyName": device.friendly_name,
+        "id": device.id,
+        "state": {
+            "metadeviceId": device.id,
+            "values": convert_states(device.states),
+        },
+        "typeId": "metadevice.device",
+    }
 
 
 def create_hs_raw_from_dump(file_name: str) -> list[dict]:


### PR DESCRIPTION
Implementation for #168


 * Goto HACS within HA
 * Click `Hubspace-HomeAssistant`
 * Click the triple dots on the top-left
 * Click `Update Information`
 *  Click the triple dots on the top-left
 * Click `Redownload`
 * Click `Show beta versions`
 * Select `dev-security-system`
 * Click `DOWNLOAD`
 * Restart HA