### PR TITLE
Remove update_decorator as it is not needed as of aioafero>=5.3.0

### DIFF
--- a/custom_components/hubspace/climate.py
+++ b/custom_components/hubspace/climate.py
@@ -29,7 +29,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .bridge import HubspaceBridge
 from .const import DOMAIN
-from .entity import HubspaceBaseEntity, update_decorator
+from .entity import HubspaceBaseEntity
 
 
 class HubspaceThermostat(HubspaceBaseEntity, ClimateEntity):
@@ -174,7 +174,6 @@ class HubspaceThermostat(HubspaceBaseEntity, ClimateEntity):
             else UnitOfTemperature.CELSIUS
         )
 
-    @update_decorator
     async def translate_hvac_mode_to_hubspace(self, hvac_mode) -> str | None:
         """Convert HomeAssistant -> Hubspace."""
         tracked_modes = {
@@ -188,7 +187,6 @@ class HubspaceThermostat(HubspaceBaseEntity, ClimateEntity):
         }
         return tracked_modes.get(hvac_mode)
 
-    @update_decorator
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new hvac mode."""
         mode = await self.translate_hvac_mode_to_hubspace(hvac_mode)
@@ -196,7 +194,6 @@ class HubspaceThermostat(HubspaceBaseEntity, ClimateEntity):
             self.controller.set_state, device_id=self.resource.id, hvac_mode=mode
         )
 
-    @update_decorator
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""
         tracked_modes = {
@@ -209,7 +206,6 @@ class HubspaceThermostat(HubspaceBaseEntity, ClimateEntity):
             fan_mode=tracked_modes.get(fan_mode, fan_mode),
         )
 
-    @update_decorator
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
         await self.bridge.async_request_call(

--- a/custom_components/hubspace/entity.py
+++ b/custom_components/hubspace/entity.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from functools import wraps
-
 from aioafero.v1 import AferoController, AferoModelResource
 from aioafero.v1.controllers.event import EventType
 from homeassistant.core import callback
@@ -80,21 +78,3 @@ class HubspaceBaseEntity(Entity):  # pylint: disable=hass-enforce-class-module
         self.logger.debug("Received status update for %s", self.entity_id)
         self.on_update()
         self.async_write_ha_state()
-
-
-def update_decorator(method):
-    """Force HA to automatically update.
-
-    Hubspace can be slow to update, which causes a delay between HA UI
-    and what the user just did. Force it to take the new states right
-    away.
-    """
-
-    @wraps(method)
-    async def _impl(*args, **kwargs):
-        res = await method(*args, **kwargs)
-        ha_entity: HubspaceBaseEntity = args[0]
-        ha_entity.handle_event(EventType.RESOURCE_UPDATED, None)
-        return res
-
-    return _impl

--- a/custom_components/hubspace/fan.py
+++ b/custom_components/hubspace/fan.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .bridge import HubspaceBridge
 from .const import DOMAIN
-from .entity import HubspaceBaseEntity, update_decorator
+from .entity import HubspaceBaseEntity
 
 PRESET_HS_TO_HA = {"comfort-breeze": "breeze"}
 
@@ -99,7 +99,6 @@ class HubspaceFan(HubspaceBaseEntity, FanEntity):
             else None
         )
 
-    @update_decorator
     async def async_turn_on(
         self,
         percentage: Optional[int] = None,
@@ -115,7 +114,6 @@ class HubspaceFan(HubspaceBaseEntity, FanEntity):
             preset=bool(preset_mode),
         )
 
-    @update_decorator
     async def async_turn_off(
         self,
         **kwargs: Any,
@@ -127,7 +125,6 @@ class HubspaceFan(HubspaceBaseEntity, FanEntity):
             on=False,
         )
 
-    @update_decorator
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
         await self.bridge.async_request_call(
@@ -137,7 +134,6 @@ class HubspaceFan(HubspaceBaseEntity, FanEntity):
             speed=percentage,
         )
 
-    @update_decorator
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
         await self.bridge.async_request_call(
@@ -147,7 +143,6 @@ class HubspaceFan(HubspaceBaseEntity, FanEntity):
             preset=bool(preset_mode),
         )
 
-    @update_decorator
     async def async_set_direction(self, direction: str) -> None:
         """Set the direction of the fan."""
         await self.bridge.async_request_call(

--- a/custom_components/hubspace/light.py
+++ b/custom_components/hubspace/light.py
@@ -22,7 +22,7 @@ from homeassistant.util.color import brightness_to_value, value_to_brightness
 
 from .bridge import HubspaceBridge
 from .const import DOMAIN
-from .entity import HubspaceBaseEntity, update_decorator
+from .entity import HubspaceBaseEntity
 
 
 class HubspaceLight(HubspaceBaseEntity, LightEntity):
@@ -137,7 +137,6 @@ class HubspaceLight(HubspaceBaseEntity, LightEntity):
             return LightEntityFeature(0) | LightEntityFeature.EFFECT
         return LightEntityFeature(0)
 
-    @update_decorator
     async def async_turn_on(self, **kwargs) -> None:
         """Turn device on."""
         brightness: int | None = None
@@ -164,7 +163,6 @@ class HubspaceLight(HubspaceBaseEntity, LightEntity):
             effect=effect,
         )
 
-    @update_decorator
     async def async_turn_off(self, **kwargs) -> None:
         """Turn device off."""
         await self.bridge.async_request_call(

--- a/custom_components/hubspace/lock.py
+++ b/custom_components/hubspace/lock.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .bridge import HubspaceBridge
 from .const import DOMAIN
-from .entity import HubspaceBaseEntity, update_decorator
+from .entity import HubspaceBaseEntity
 
 
 class HubspaceLock(HubspaceBaseEntity, LockEntity):
@@ -62,7 +62,6 @@ class HubspaceLock(HubspaceBaseEntity, LockEntity):
         """Indication of whether the lock is currently open."""
         return self.resource.position.position == features.CurrentPositionEnum.UNLOCKED
 
-    @update_decorator
     async def async_unlock(self, **kwargs) -> None:
         """Unlock all or specified locks."""
         self.logger.info("Unlocking %s [%s]", self.name, self.resource.id)
@@ -72,7 +71,6 @@ class HubspaceLock(HubspaceBaseEntity, LockEntity):
             lock_position=features.CurrentPositionEnum.UNLOCKING,
         )
 
-    @update_decorator
     async def async_lock(self, **kwargs) -> None:
         """Lock all or specified locks."""
         self.logger.info("Unlocking %s [%s]", self.name, self.resource.id)

--- a/custom_components/hubspace/manifest.json
+++ b/custom_components/hubspace/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jdeath/Hubspace-Homeassistant/issues",
   "loggers": ["aioafero"],
-  "requirements": ["aioafero==5.2.2", "aiofiles"],
+  "requirements": ["aioafero==5.3.0", "aiofiles"],
   "version": "5.7.1"
 }

--- a/custom_components/hubspace/number.py
+++ b/custom_components/hubspace/number.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .bridge import HubspaceBridge
 from .const import DOMAIN
-from .entity import HubspaceBaseEntity, update_decorator
+from .entity import HubspaceBaseEntity
 
 
 class AferoNumberEntity(HubspaceBaseEntity, NumberEntity):
@@ -54,7 +54,6 @@ class AferoNumberEntity(HubspaceBaseEntity, NumberEntity):
         """The unit of measurement that the sensor's value is expressed in."""
         return self.resource.numbers[self._identifier].unit
 
-    @update_decorator
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         await self.bridge.async_request_call(

--- a/custom_components/hubspace/select.py
+++ b/custom_components/hubspace/select.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .bridge import HubspaceBridge
 from .const import DOMAIN
-from .entity import HubspaceBaseEntity, update_decorator
+from .entity import HubspaceBaseEntity
 
 
 class AferoSelectEntitiy(HubspaceBaseEntity, SelectEntity):
@@ -40,7 +40,6 @@ class AferoSelectEntitiy(HubspaceBaseEntity, SelectEntity):
         """A list of available options as strings."""
         return sorted(self.resource.selects[self._identifier].selects)
 
-    @update_decorator
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.bridge.async_request_call(

--- a/custom_components/hubspace/switch.py
+++ b/custom_components/hubspace/switch.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .bridge import HubspaceBridge
 from .const import DOMAIN
-from .entity import HubspaceBaseEntity, update_decorator
+from .entity import HubspaceBaseEntity
 
 
 class HubspaceSwitch(HubspaceBaseEntity, SwitchEntity):
@@ -39,7 +39,6 @@ class HubspaceSwitch(HubspaceBaseEntity, SwitchEntity):
             return feature.on
         return None
 
-    @update_decorator
     async def async_turn_on(
         self,
         **kwargs: Any,
@@ -53,7 +52,6 @@ class HubspaceSwitch(HubspaceBaseEntity, SwitchEntity):
             instance=self.instance,
         )
 
-    @update_decorator
     async def async_turn_off(
         self,
         **kwargs: Any,

--- a/custom_components/hubspace/valve.py
+++ b/custom_components/hubspace/valve.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .bridge import HubspaceBridge
 from .const import DOMAIN
-from .entity import HubspaceBaseEntity, update_decorator
+from .entity import HubspaceBaseEntity
 
 
 class HubspaceValve(HubspaceBaseEntity, ValveEntity):
@@ -59,7 +59,6 @@ class HubspaceValve(HubspaceBaseEntity, ValveEntity):
             return 100 if feature.open else 0
         return None
 
-    @update_decorator
     async def async_open_valve(self, **kwargs) -> None:
         """Open the valve."""
         self.logger.info("Opening valve on %s", self._attr_name)
@@ -70,7 +69,6 @@ class HubspaceValve(HubspaceBaseEntity, ValveEntity):
             instance=self.instance,
         )
 
-    @update_decorator
     async def async_close_valve(self, **kwargs) -> None:
         """Close valve."""
         self.logger.info("Closing valve on %s", self._attr_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 homeassistant
-aioafero>=5.1.1
+aioafero>=5.3.0
 aiofiles>=24.1.0

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -1,6 +1,5 @@
 """Test the integration between Home Assistant Fans and Afero devices."""
 
-from aioafero import AferoState
 from homeassistant.components.fan import (
     ATTR_DIRECTION,
     ATTR_PERCENTAGE,
@@ -9,7 +8,7 @@ from homeassistant.components.fan import (
 from homeassistant.helpers import entity_registry as er
 import pytest
 
-from .utils import create_devices_from_data, hs_raw_from_dump, modify_state
+from .utils import create_devices_from_data, hs_raw_from_dump
 
 fan_zandra = create_devices_from_data("fan-ZandraFan.json")
 fan_zandra_instance = fan_zandra[0]
@@ -68,10 +67,7 @@ async def test_turn_on(mocked_entity):
         {"entity_id": fan_zandra_entity_id, ATTR_PERCENTAGE: 50},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == fan_zandra_instance.id
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(fan_zandra_entity_id)
     assert entity is not None
@@ -95,56 +91,13 @@ async def test_turn_on_preset(mocked_entity):
         },
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == fan_zandra_instance.id
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(fan_zandra_entity_id)
     assert entity is not None
     assert entity.state == "on"
     assert entity.attributes[ATTR_PERCENTAGE] == 50
     assert entity.attributes[ATTR_PRESET_MODE] == "breeze"
-
-
-@pytest.mark.asyncio
-async def test_turn_on_limited(mocked_entry):
-    """Ensure the service call turn_on works as expected."""
-    hass, entry, bridge = mocked_entry
-    await bridge.generate_devices_from_data(exhaust_fan)
-    bridge.fans[exhaust_fan_instance.id].on.on = False
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    await hass.services.async_call(
-        "fan",
-        "turn_on",
-        {"entity_id": exhaust_fan_instance_entity_id},
-        blocking=True,
-    )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == exhaust_fan_instance.id
-    update = payload["values"][0]
-    assert update["functionClass"] == "power"
-    assert update["functionInstance"] == "fan-power"
-    assert update["value"] == "on"
-    # Now generate update event by emitting the json we've sent as incoming event
-    exhaust_fan_update = create_devices_from_data("fan-exhaust-fan.json")[3]
-    modify_state(
-        exhaust_fan_update,
-        AferoState(
-            functionClass="power",
-            functionInstance="fan-power",
-            value="on",
-        ),
-    )
-    await bridge.generate_devices_from_data([exhaust_fan_update])
-    await hass.async_block_till_done()
-    assert bridge.fans[exhaust_fan_update.id].on.on
-    test_entity = hass.states.get(exhaust_fan_instance_entity_id)
-    assert test_entity is not None
-    assert test_entity.state == "on"
 
 
 @pytest.mark.asyncio
@@ -158,10 +111,7 @@ async def test_turn_off(mocked_entity):
         {"entity_id": fan_zandra_entity_id},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == fan_zandra_instance.id
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(fan_zandra_entity_id)
     assert entity is not None
@@ -179,11 +129,7 @@ async def test_set_percentage(mocked_entity):
         {"entity_id": fan_zandra_entity_id, "percentage": 100},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == fan_zandra_instance.id
-    assert payload["values"][1]["value"] == "fan-speed-6-100"
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(fan_zandra_entity_id)
     assert entity is not None
@@ -203,12 +149,7 @@ async def test_set_preset_mode(mocked_entity):
         {"entity_id": fan_zandra_entity_id, ATTR_PRESET_MODE: "breeze"},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == fan_zandra_instance.id
-    assert payload["values"][1]["functionInstance"] == "comfort-breeze"
-    assert payload["values"][1]["value"] == "enabled"
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(fan_zandra_entity_id)
     assert entity is not None
@@ -228,11 +169,7 @@ async def test_set_direction(mocked_entity):
         {"entity_id": fan_zandra_entity_id, "direction": "forward"},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == fan_zandra_instance.id
-    assert payload["values"][1]["value"] == "forward"
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(fan_zandra_entity_id)
     assert entity is not None
@@ -245,11 +182,7 @@ async def test_set_direction(mocked_entity):
         {"entity_id": fan_zandra_entity_id, "direction": "reverse"},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == fan_zandra_instance.id
-    assert payload["values"][0]["value"] == "reverse"
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(fan_zandra_entity_id)
     assert entity is not None

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,6 +1,5 @@
 """Test the integration between Home Assistant Lights and Afero devices."""
 
-from aioafero import AferoState
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_MODE,
@@ -14,7 +13,7 @@ import pytest
 
 from custom_components.hubspace import light
 
-from .utils import create_devices_from_data, hs_raw_from_dump, modify_state
+from .utils import create_devices_from_data, hs_raw_from_dump
 
 fan_zandra = create_devices_from_data("fan-ZandraFan.json")
 fan_zandra_light = fan_zandra[1]
@@ -127,36 +126,7 @@ async def test_turn_on(mocked_entity):
         {"entity_id": light_a21_id, ATTR_BRIGHTNESS: 64},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == light_a21.id
-    assert len(payload["values"]) == 2
-    power_payload = payload["values"][0]
-    brightness_payload = payload["values"][1]
-    assert power_payload["functionClass"] == "power"
-    assert power_payload["functionInstance"] is None
-    assert power_payload["value"] == "on"
-    assert brightness_payload["value"] == 25
-    # Now generate update event by emitting the json we've sent as incoming event
-    hs_device_update = create_devices_from_data("light-a21.json")[0]
-    modify_state(
-        hs_device_update,
-        AferoState(
-            functionClass="power",
-            functionInstance=None,
-            value="on",
-        ),
-    )
-    modify_state(
-        hs_device_update,
-        AferoState(
-            functionClass="brightness",
-            functionInstance=None,
-            value=25,
-        ),
-    )
-    await bridge.generate_devices_from_data([hs_device_update])
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(light_a21_id)
     assert entity is not None
@@ -177,44 +147,7 @@ async def test_turn_on_temp(mocked_entity):
         {"entity_id": light_a21_id, ATTR_COLOR_TEMP_KELVIN: 3000},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == light_a21.id
-    assert len(payload["values"]) == 3
-    power_payload = payload["values"][0]
-    assert power_payload["functionClass"] == "power"
-    assert power_payload["functionInstance"] is None
-    assert power_payload["value"] == "on"
-    assert payload["values"][1]["value"] == "white"
-    assert payload["values"][2]["value"] == "3000"
-    # Now generate update event by emitting the json we've sent as incoming event
-    hs_device_update = create_devices_from_data("light-a21.json")[0]
-    modify_state(
-        hs_device_update,
-        AferoState(
-            functionClass="power",
-            functionInstance=None,
-            value="on",
-        ),
-    )
-    modify_state(
-        hs_device_update,
-        AferoState(
-            functionClass="color-temperature",
-            functionInstance=None,
-            value=3000,
-        ),
-    )
-    modify_state(
-        hs_device_update,
-        AferoState(
-            functionClass="color-mode",
-            functionInstance=None,
-            value="white",
-        ),
-    )
-    await bridge.generate_devices_from_data([hs_device_update])
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(light_a21_id)
     assert entity is not None
@@ -236,50 +169,7 @@ async def test_turn_on_color(mocked_entity):
         {"entity_id": light_a21_id, ATTR_RGB_COLOR: (50, 100, 150)},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == light_a21.id
-    assert len(payload["values"]) == 3
-    power_payload = payload["values"][0]
-    assert power_payload["functionClass"] == "power"
-    assert power_payload["functionInstance"] is None
-    assert power_payload["value"] == "on"
-    assert payload["values"][1]["value"] == {"color-rgb": {"b": 150, "g": 100, "r": 50}}
-    assert payload["values"][2]["value"] == "color"
-    # Now generate update event by emitting the json we've sent as incoming event
-    hs_device_update = create_devices_from_data("light-a21.json")[0]
-    modify_state(
-        hs_device_update,
-        AferoState(
-            functionClass="power",
-            functionInstance=None,
-            value="on",
-        ),
-    )
-    modify_state(
-        hs_device_update,
-        AferoState(
-            functionClass="color-rgb",
-            functionInstance=None,
-            value={
-                "color-rgb": {
-                    "r": 50,
-                    "g": 100,
-                    "b": 150,
-                }
-            },
-        ),
-    )
-    modify_state(
-        hs_device_update,
-        AferoState(
-            functionClass="color-mode",
-            functionInstance=None,
-            value="color",
-        ),
-    )
-    await bridge.generate_devices_from_data([hs_device_update])
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(light_a21_id)
     assert entity is not None
@@ -302,53 +192,7 @@ async def test_turn_on_effect(mocked_entity):
         {"entity_id": light_a21_id, ATTR_EFFECT: "rainbow"},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == light_a21.id
-    assert len(payload["values"]) == 4
-    power_payload = payload["values"][0]
-    assert power_payload["functionClass"] == "power"
-    assert power_payload["functionInstance"] is None
-    assert power_payload["value"] == "on"
-    assert payload["values"][1]["value"] == "sequence"
-    assert payload["values"][2]["value"] == "custom"
-    assert payload["values"][3]["value"] == "rainbow"
-    # Now generate update event by emitting the json we've sent as incoming event
-    hs_device_update = create_devices_from_data("light-a21.json")[0]
-    modify_state(
-        hs_device_update,
-        AferoState(
-            functionClass="power",
-            functionInstance=None,
-            value="on",
-        ),
-    )
-    modify_state(
-        hs_device_update,
-        AferoState(
-            functionClass="color-mode",
-            functionInstance=None,
-            value="sequence",
-        ),
-    )
-    modify_state(
-        hs_device_update,
-        AferoState(
-            functionClass="color-sequence",
-            functionInstance="preset",
-            value="custom",
-        ),
-    )
-    modify_state(
-        hs_device_update,
-        AferoState(
-            functionClass="color-sequence",
-            functionInstance="custom",
-            value="rainbow",
-        ),
-    )
-    await bridge.generate_devices_from_data([hs_device_update])
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     assert bridge.lights[light_a21.id].effect.effect == "rainbow"
     assert bridge.lights[light_a21.id].color_mode.mode == "sequence"
@@ -370,25 +214,7 @@ async def test_turn_on_dimmer(mocked_dimmer):
         {"entity_id": switch_dimmer_light_id},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == switch_dimmer_light.id
-    update = payload["values"][0]
-    assert update["functionClass"] == "power"
-    assert update["functionInstance"] == "gang-1"
-    assert update["value"] == "on"
-    # Now generate update event by emitting the json we've sent as incoming event
-    switch_dimmer_update = create_devices_from_data("dimmer-HPDA1110NWBP.json")[0]
-    modify_state(
-        switch_dimmer_update,
-        AferoState(
-            functionClass="power",
-            functionInstance="gang-1",
-            value="on",
-        ),
-    )
-    await bridge.generate_devices_from_data([switch_dimmer_update])
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(switch_dimmer_light_id)
     assert entity is not None
@@ -406,10 +232,7 @@ async def test_turn_off(mocked_entity):
         {"entity_id": light_a21_id},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == light_a21.id
+    await bridge.async_block_until_done()
     entity = hass.states.get(light_a21_id)
     assert entity is not None
     assert entity.state == "off"
@@ -427,26 +250,7 @@ async def test_turn_off_dimmer(mocked_dimmer):
         {"entity_id": switch_dimmer_light_id},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == switch_dimmer_light.id
-    update = payload["values"][0]
-    assert update["functionClass"] == "power"
-    assert update["functionInstance"] == "gang-1"
-    assert update["value"] == "off"
-    assert not bridge.lights[switch_dimmer_light.id].is_on
-    # Now generate update event by emitting the json we've sent as incoming event
-    switch_dimmer_update = create_devices_from_data("dimmer-HPDA1110NWBP.json")[0]
-    modify_state(
-        switch_dimmer_update,
-        AferoState(
-            functionClass="power",
-            functionInstance="gang-1",
-            value="off",
-        ),
-    )
-    await bridge.generate_devices_from_data([switch_dimmer_update])
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(switch_dimmer_light_id)
     assert entity is not None

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -60,25 +60,8 @@ async def test_unlock(mocked_entity):
         {"entity_id": lock_id},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == lock_tbd_instance.id
-    update = payload["values"][0]
-    assert update["functionClass"] == "lock-control"
-    assert update["functionInstance"] is None
-    assert update["value"] == "unlocking"
-    # Now generate update event by emitting the json we've sent as incoming event
     lock_update = create_devices_from_data("door-lock-TBD.json")[0]
-    modify_state(
-        lock_update,
-        AferoState(
-            functionClass="lock-control",
-            functionInstance=None,
-            value="unlocking",
-        ),
-    )
-    await bridge.generate_devices_from_data([lock_update])
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     assert (
         bridge.locks[lock_update.id].position.position
@@ -97,25 +80,8 @@ async def test_lock(mocked_entity):
         {"entity_id": lock_id},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == lock_tbd_instance.id
-    update = payload["values"][0]
-    assert update["functionClass"] == "lock-control"
-    assert update["functionInstance"] is None
-    assert update["value"] == "locking"
-    # Now generate update event by emitting the json we've sent as incoming event
     lock_update = create_devices_from_data("door-lock-TBD.json")[0]
-    modify_state(
-        lock_update,
-        AferoState(
-            functionClass="lock-control",
-            functionInstance=None,
-            value="locking",
-        ),
-    )
-    await bridge.generate_devices_from_data([lock_update])
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     assert (
         bridge.locks[lock_update.id].position.position
@@ -133,6 +99,7 @@ async def test_lock(mocked_entity):
         ),
     )
     await bridge.generate_devices_from_data([lock_update])
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     assert (
         bridge.locks[lock_update.id].position.position

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -87,26 +87,7 @@ async def test_set_value(mocked_entity):
         {"entity_id": exhaust_fan_number_id, "value": 120},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == exhaust_fan.id
-    assert len(payload["values"]) == 1
-    payload = payload["values"][0]
-    assert payload["functionClass"] == "auto-off-timer"
-    assert payload["functionInstance"] == "auto-off"
-    assert payload["value"] == 120
-    # Now generate update event by emitting the json we've sent as incoming event
-    hs_device_update = create_devices_from_data("fan-exhaust-fan.json")[2]
-    modify_state(
-        hs_device_update,
-        AferoState(
-            functionClass="auto-off-timer",
-            functionInstance="auto-off",
-            value=120,
-        ),
-    )
-    await bridge.generate_devices_from_data([hs_device_update])
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(exhaust_fan_number_id)
     assert entity is not None

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -90,26 +90,7 @@ async def test_set_value(mocked_entity):
         {"entity_id": exhaust_fan_id, "option": "5-high"},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == exhaust_fan.id
-    assert len(payload["values"]) == 1
-    payload = payload["values"][0]
-    assert payload["functionClass"] == "sensitivity"
-    assert payload["functionInstance"] == "humidity-sensitivity"
-    assert payload["value"] == "5-high"
-    # Now generate update event by emitting the json we've sent as incoming event
-    hs_device_update = create_devices_from_data("fan-exhaust-fan.json")
-    modify_state(
-        hs_device_update[2],
-        AferoState(
-            functionClass="sensitivity",
-            functionInstance="humidity-sensitivity",
-            value="5-high",
-        ),
-    )
-    await bridge.generate_devices_from_data(hs_device_update)
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(exhaust_fan_id)
     assert entity is not None

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -29,6 +29,7 @@ async def mocked_entity(mocked_entry):
     await bridge.close()
 
 
+# @TODO - Manually mock afero_api_response
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     (
@@ -54,12 +55,26 @@ async def mocked_entity(mocked_entry):
     ],
 )
 async def test_service_valid_no_username(
-    account, entity_id, error_entity, error_bridge, mocked_entity, caplog
+    account, entity_id, error_entity, error_bridge, mocked_entity, caplog, mocker
 ):
     """Ensure the correct states are sent and the entity is properly updated."""
     hass, _, bridge = mocked_entity
     assert hass.states.get(fan_zandra_light_id).state == "on"
     if not error_entity and not error_bridge:
+        resp = mocker.AsyncMock()
+        resp.json = mocker.AsyncMock(
+            return_value={
+                "metadeviceId": fan_zandra_light.id,
+                "values": [
+                    {
+                        "functionClass": "power",
+                        "functionInstance": "light-power",
+                        "value": "off",
+                    }
+                ],
+            }
+        )
+        mocker.patch.object(bridge.lights, "update_afero_api", return_value=resp)
         await hass.services.async_call(
             const.DOMAIN,
             services.SERVICE_SEND_COMMAND,
@@ -74,17 +89,6 @@ async def test_service_valid_no_username(
         )
         await bridge.async_block_until_done()
         await hass.async_block_till_done()
-        update_call = bridge.request.call_args_list[-1]
-        assert update_call.args[0] == "put"
-        payload = update_call.kwargs["json"]
-        assert payload["metadeviceId"] == fan_zandra_light.id
-        assert payload["values"] == [
-            {
-                "functionClass": "power",
-                "functionInstance": "light-power",
-                "value": "off",
-            }
-        ]
         # Now generate update event by emitting the json we've sent as incoming event
         light_update = create_devices_from_data("fan-ZandraFan.json")[1]
         modify_state(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -29,7 +29,6 @@ async def mocked_entity(mocked_entry):
     await bridge.close()
 
 
-# @TODO - Manually mock afero_api_response
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     (

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,10 +1,9 @@
 """Test the integration between Home Assistant Switches and Afero devices."""
 
-from aioafero import AferoState
 from homeassistant.helpers import entity_registry as er
 import pytest
 
-from .utils import create_devices_from_data, hs_raw_from_dump, modify_state
+from .utils import create_devices_from_data, hs_raw_from_dump
 
 transformer_from_file = create_devices_from_data("transformer.json")
 transformer = transformer_from_file[0]
@@ -114,25 +113,7 @@ async def test_turn_on_toggle(mocked_entity_toggled):
         {"entity_id": transformer_entity_zone_3},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == transformer.id
-    update = payload["values"][0]
-    assert update["functionClass"] == "toggle"
-    assert update["functionInstance"] == "zone-3"
-    assert update["value"] == "on"
-    # Now generate update event by emitting the json we've sent as incoming event
-    transformer_update = create_devices_from_data("transformer.json")
-    modify_state(
-        transformer_update[0],
-        AferoState(
-            functionClass="toggle",
-            functionInstance="zone-3",
-            value="on",
-        ),
-    )
-    await bridge.generate_devices_from_data(transformer_update)
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(transformer_entity_zone_3)
     assert entity is not None
@@ -151,25 +132,7 @@ async def test_turn_on(mocked_entity):
         {"entity_id": hs_switch_id},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == hs_switch.id
-    update = payload["values"][0]
-    assert update["functionClass"] == "power"
-    assert update["functionInstance"] is None
-    assert update["value"] == "on"
-    # Now generate update event by emitting the json we've sent as incoming event
-    hs_switch_update = create_devices_from_data("switch-HPSA11CWB.json")
-    modify_state(
-        hs_switch_update[0],
-        AferoState(
-            functionClass="power",
-            functionInstance=None,
-            value="on",
-        ),
-    )
-    await bridge.generate_devices_from_data(hs_switch_update)
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(hs_switch_id)
     assert entity is not None
@@ -186,21 +149,7 @@ async def test_turn_off_toggle(mocked_entity_toggled):
         {"entity_id": transformer_entity_zone_2},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == transformer.id
-    # Now generate update event by emitting the json we've sent as incoming event
-    transformer_update = create_devices_from_data("transformer.json")[0]
-    modify_state(
-        transformer_update,
-        AferoState(
-            functionClass="toggle",
-            functionInstance="zone-2",
-            value="off",
-        ),
-    )
-    await bridge.generate_devices_from_data([transformer_update])
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(transformer_entity_zone_2)
     assert entity is not None
@@ -219,25 +168,7 @@ async def test_turn_off(mocked_entity):
         {"entity_id": hs_switch_id},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == hs_switch.id
-    update = payload["values"][0]
-    assert update["functionClass"] == "power"
-    assert update["functionInstance"] is None
-    assert update["value"] == "off"
-    # Now generate update event by emitting the json we've sent as incoming event
-    hs_switch_update = create_devices_from_data("switch-HPSA11CWB.json")[0]
-    modify_state(
-        hs_switch_update,
-        AferoState(
-            functionClass="toggle",
-            functionInstance=None,
-            value="off",
-        ),
-    )
-    await bridge.generate_devices_from_data([hs_switch_update])
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     test_switch = hass.states.get(hs_switch_id)
     assert test_switch is not None
@@ -287,6 +218,7 @@ async def test_exhaust_fan_names(mocked_exhaust_fan):
         assert entity_reg.async_get(entity) is not None
 
 
+# @TODO - Fix for split device
 @pytest.mark.asyncio
 async def test_light_speaker_power(mocked_light_speaker):
     """Ensure that the light speaker creates a switch."""
@@ -301,25 +233,7 @@ async def test_light_speaker_power(mocked_light_speaker):
         {"entity_id": speaker_light_id},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == "3bec6eaa-3d87-4f3c-a065-a2b32f87c39f"
-    update = payload["values"][0]
-    assert update["functionClass"] == "toggle"
-    assert update["functionInstance"] == "speaker-power"
-    assert update["value"] == "on"
-    # Now generate update event by emitting the json we've sent as incoming event
-    hs_switch_update = create_devices_from_data("light-with-speaker.json")
-    modify_state(
-        hs_switch_update[0],
-        AferoState(
-            functionClass="toggle",
-            functionInstance="speaker-power",
-            value="on",
-        ),
-    )
-    await bridge.generate_devices_from_data(hs_switch_update)
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     test_switch = hass.states.get(speaker_light_id)
     assert test_switch is not None

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -218,7 +218,6 @@ async def test_exhaust_fan_names(mocked_exhaust_fan):
         assert entity_reg.async_get(entity) is not None
 
 
-# @TODO - Fix for split device
 @pytest.mark.asyncio
 async def test_light_speaker_power(mocked_light_speaker):
     """Ensure that the light speaker creates a switch."""

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -1,11 +1,10 @@
 """Test the integration between Home Assistant Valves and Afero devices."""
 
-from aioafero import AferoState
 from homeassistant.components.valve import ATTR_CURRENT_POSITION
 from homeassistant.helpers import entity_registry as er
 import pytest
 
-from .utils import create_devices_from_data, hs_raw_from_dump, modify_state
+from .utils import create_devices_from_data, hs_raw_from_dump
 
 spigot_from_file = create_devices_from_data("water-timer.json")
 spigot = spigot_from_file[0]
@@ -63,24 +62,7 @@ async def test_open_valve(mocked_entity):
         {"entity_id": spigot_1},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == spigot.id
-    assert payload["values"][0]["functionClass"] == "toggle"
-    assert payload["values"][0]["functionInstance"] == "spigot-1"
-    assert payload["values"][0]["value"] == "on"
-    # Now generate update event by emitting the json we've sent as incoming event
-    hs_device = create_devices_from_data("water-timer.json")[0]
-    modify_state(
-        hs_device,
-        AferoState(
-            functionClass="toggle",
-            functionInstance="spigot-1",
-            value="on",
-        ),
-    )
-    await bridge.generate_devices_from_data([hs_device])
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(spigot_1)
     assert entity is not None
@@ -98,24 +80,7 @@ async def test_close_valve(mocked_entity):
         {"entity_id": spigot_2},
         blocking=True,
     )
-    update_call = bridge.request.call_args_list[-1]
-    assert update_call.args[0] == "put"
-    payload = update_call.kwargs["json"]
-    assert payload["metadeviceId"] == spigot.id
-    assert payload["values"][0]["functionClass"] == "toggle"
-    assert payload["values"][0]["functionInstance"] == "spigot-2"
-    assert payload["values"][0]["value"] == "off"
-    # Now generate update event by emitting the json we've sent as incoming event
-    hs_device = create_devices_from_data("water-timer.json")[0]
-    modify_state(
-        hs_device,
-        AferoState(
-            functionClass="toggle",
-            functionInstance="spigot-2",
-            value="off",
-        ),
-    )
-    await bridge.generate_devices_from_data([hs_device])
+    await bridge.async_block_until_done()
     await hass.async_block_till_done()
     entity = hass.states.get(spigot_1)
     assert entity is not None


### PR DESCRIPTION
Improve state status by ensuring the state is synced with Afero rather than assuming via state updates.