### PR TITLE
Align local tox and CI on dynamic HA matrix from hacs.json

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,35 +1,95 @@
 ---
 name: Execute tests and linting
+
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0"
   push:
     branches:
       - main
   pull_request:
+
 jobs:
-  run_tests:
+  lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version:
-          - "3.13"
-        ha_version:
-          - "2025.7"
-          - "2025.8"
-          - "2025.9"
-          - "2025.10"
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install requirements
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            test-requirements.txt
+            tox.ini
+            toxfile.py
+      - name: Run pre-commit (tox -e lint)
         run: |
-          pip install -r requirements.txt -r test-requirements.txt homeassistant==${{ matrix.ha_version }}
-      - name: Execute Tests
+          pip install tox
+          tox -e lint
+
+  matrix-prep:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Restore phcc PyPI version index
+        uses: actions/cache@v5
+        with:
+          path: .tox/phcc_version_index.json
+          key: phcc-index-${{ hashFiles('scripts/phcc_matrix.py', 'hacs.json', 'toxfile.py') }}
+          restore-keys: |
+            phcc-index-
+      - name: Build tox matrix and phcc index (once per workflow)
+        id: matrix
         run: |
-          pytest
-      - name: Execute Linting
+          echo "matrix=$(python scripts/phcc_matrix.py --github-matrix)" >> "$GITHUB_OUTPUT"
+      - name: Upload phcc version index
+        uses: actions/upload-artifact@v7
+        with:
+          name: phcc-version-index
+          path: .tox/phcc_version_index.json
+          retention-days: 1
+
+  homeassistant:
+    runs-on: ubuntu-latest
+    needs: matrix-prep
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.matrix-prep.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download phcc version index
+        uses: actions/download-artifact@v8
+        with:
+          name: phcc-version-index
+          path: .tox
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: |
+            custom_components/hubspace/manifest.json
+            test-requirements.txt
+            tox.ini
+            toxfile.py
+            scripts/phcc_matrix.py
+            scripts/tox_ha_install.py
+            hacs.json
+      - name: Run tox (${{ matrix.toxenv }})
+        env:
+          PHCC_INDEX_OFFLINE: "1"
         run: |
-          pre-commit run --all-files
+          pip install tox
+          tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
             toxfile.py
       - name: Run pre-commit (tox -e lint)
         run: |
-          pip install tox
+          pip install -r test-requirements.txt
           tox -e lint
 
   matrix-prep:
@@ -91,5 +91,5 @@ jobs:
         env:
           PHCC_INDEX_OFFLINE: "1"
         run: |
-          pip install tox
+          pip install 'tox>=4.29,<6'
           tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,5 +91,5 @@ jobs:
         env:
           PHCC_INDEX_OFFLINE: "1"
         run: |
-          pip install 'tox>=4.29,<6'
+          pip install -r test-requirements.txt
           tox -e ${{ matrix.toxenv }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 __pycache__
+.tox/
 .idea/
 custom_components/hubspace/dump_*.json
 .coverage
 *.egg-info
+
+uv.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         args:
           - --fix
       - id: ruff-format
-        files: ^((custom_components|tests)/.+)?[^/]+\.(py|pyi)$
+        files: ^((custom_components|tests|scripts)/.+)?[^/]+\.(py|pyi)$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:
@@ -55,4 +55,4 @@ repos:
           - --py311-plus
           - --force
           - --keep-updates
-        files: ^(custom_components|tests)/.+\.py$
+        files: ^(custom_components|tests|scripts)/.+\.py$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+Thank you for contributing to Hubspace Home Assistant.
+
+- **Integration testing, tox, and CI** — [docs/testing.md](docs/testing.md#quick-start-local) (ordered local setup; not shown in HACS; `README.md` is the HACS-facing doc).
+- **Issues and feature requests** — use [GitHub Issues](https://github.com/jdeath/Hubspace-Homeassistant/issues).
+
+Before opening a pull request, run lint and at least one relevant tox HA environment (see the testing guide quick start), or the full parallel matrix.

--- a/custom_components/hubspace/bridge.py
+++ b/custom_components/hubspace/bridge.py
@@ -155,6 +155,11 @@ class HubspaceBridge:
             self.config_entry, PLATFORMS
         )
 
+        try:
+            await self.api.close()
+        except Exception:
+            self.logger.exception("Error closing Hubspace API connection")
+
         if unload_success:
             self.hass.data[DOMAIN].pop(self.config_entry.entry_id)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -115,7 +115,7 @@ Tox `install_command` hook. For HA envs it installs `test-requirements.txt`, man
 Tox 4 plugin loaded from the repo root. Appends HA env names to `envlist` so `tox run-parallel` matches CI without a long static list in git. Python interpreters come from `basepython` factors in `tox.ini` (add a line when a new `py315` prefix appears).
 
 - `tox -e lint` — does not load the phcc index for env registration.
-- `tox -e py313-ha202510` — registers only the named HA env(s); does not enumerate the full matrix.
+- `tox -e py313-ha202510` or `tox -e lint,py313-ha202510` — registers only the named HA env(s); does not enumerate the full matrix.
 - `tox -av` / `tox run-parallel` — discovers all HA envs via `list_tox_envs()` (may update the index).
 
 ## GitHub Actions
@@ -124,7 +124,9 @@ Workflow: `.github/workflows/ci.yaml`
 
 1. **lint** — `tox -e lint`
 2. **matrix-prep** — builds/updates `.tox/phcc_version_index.json` once, runs `--github-matrix`, uploads the index as a workflow artifact
-3. **homeassistant** — one job per matrix row; downloads the index artifact, sets `PHCC_INDEX_OFFLINE=1`, then `tox -e ${{ matrix.toxenv }}` (no per-job PyPI phcc indexing)
+3. **homeassistant** — one job per matrix row; downloads the index artifact, sets `PHCC_INDEX_OFFLINE=1`, installs `tox>=4.29`, then `tox -e ${{ matrix.toxenv }}` (no per-job PyPI phcc indexing)
+
+CI installs tox from `test-requirements.txt` in **lint** and `tox>=4.29,<6` in matrix jobs (tox alone is enough there; HA envs pull test deps via tox).
 
 Caches: pip wheels (per job, via `setup-python`); phcc index warm-start in **matrix-prep** only (`actions/cache` on `.tox/phcc_version_index.json`). Matrix jobs use the artifact from the same workflow run, not a separate index rebuild. Full tox venvs are **not** cached in CI.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,164 @@
+# Testing and CI
+
+This document describes how integration tests are run locally and in GitHub Actions. It is **not** shown in HACS (the HACS UI uses `README.md` only).
+
+## Quick start (local)
+
+Do these steps in order the first time you run tests on a machine.
+
+1. **Clone the repo** and open a shell in the repository root.
+
+2. **Install Python interpreters** used by the matrix (today **3.13** and **3.14**). Each HA month’s tox env uses the version Home Assistant declares on PyPI (`Requires-Python`); see [New Python for newer HA months](#new-python-for-newer-ha-months) when another version appears. List months and Python tags with `python scripts/phcc_matrix.py` or `tox -av`.
+
+3. **Install dev headers on Linux** for every interpreter you will use, e.g. `python3.13-dev` and `python3.14-dev` (or your distro’s equivalent). Without them, HA dependency installs can fail with `Python.h: No such file or directory`.
+
+4. **Create a venv and install test tools** (includes tox ≥ 4.29):
+
+   ```bash
+   python3.13 -m venv .venv
+   source .venv/bin/activate
+   pip install -U pip
+   pip install -r test-requirements.txt
+   ```
+
+5. **Lint:**
+
+   ```bash
+   tox -e lint
+   ```
+
+6. **One HA release month** (name from `tox -av` or `python scripts/phcc_matrix.py`):
+
+   ```bash
+   tox -e py313-ha202510
+   ```
+
+   First run may take several minutes while `scripts/phcc_matrix.py` builds `.tox/phcc_version_index.json` from PyPI (network required). Later runs reuse the cache.
+
+7. **Full matrix (optional)** — after lint passes:
+
+   ```bash
+   tox run-parallel -p auto -o --skip-env lint
+   ```
+
+   Tox 4 uses `run-parallel`, not `-j`. `-o` streams output live.
+
+**Subset of tests:** append paths after `--`, e.g. `tox -e py313-ha202510 -- tests/test_light.py -q`.
+
+**Inspect CI matrix without running tests:** `python scripts/phcc_matrix.py --github-matrix`.
+
+## Overview
+
+Tests use [tox](https://tox.wiki/) with one environment per supported **Home Assistant release month**. Each environment installs:
+
+- **Home Assistant** and **pytest-homeassistant-custom-component** (phcc) for that month
+- **Integration dependencies** from `custom_components/hubspace/manifest.json` (same pins HACS uses)
+- **Test tools** from `test-requirements.txt`
+
+Linting runs separately via pre-commit (`tox -e lint`).
+
+### Local vs CI matrix (aligned)
+
+Both use **`hacs.json`** (minimum month) and **`scripts/phcc_matrix.py`** (through latest PyPI month, phcc-backed, Python from `Requires-Python`):
+
+|           | Mechanism                                                                                                                                   |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| **CI**    | `matrix-prep` → `--github-matrix` → one job per `toxenv`                                                                                    |
+| **Local** | Root **`toxfile.py`** → extends `envlist` with the same names; `tox.ini` `basepython` factors (`py313`, `py314`, …) match env name prefixes |
+
+Committed **`tox.ini`** only defines shared `[testenv]` settings and `lint`; `toxfile.py` supplies HA env names from `hacs.json`.
+
+## Sources of truth
+
+| What                          | File / tool                                                                    |
+| ----------------------------- | ------------------------------------------------------------------------------ |
+| Minimum HA version to test    | `hacs.json` → `"homeassistant"` (e.g. `2025.7`)                                |
+| Maximum HA month to test      | Latest release on PyPI (`homeassistant` package), via `scripts/phcc_matrix.py` |
+| Integration runtime deps      | `custom_components/hubspace/manifest.json` → `"requirements"`                  |
+| phcc / exact HA pin per month | `scripts/phcc_matrix.py` + `.tox/phcc_version_index.json`                      |
+| Python version per tox env    | PyPI `Requires-Python` on each `homeassistant` release (via phcc index)        |
+| Local tox env names           | `toxfile.py` + `phcc_matrix.list_tox_envs()`                                   |
+
+There is **no** `requirements.txt` for the integration; tox installs from the manifest.
+
+## Prerequisites (reference)
+
+- **Python** — versions on `PATH` for every env `tox -av` lists.
+- **tox ≥ 4.29** — from `test-requirements.txt` (loads `toxfile.py`).
+- **Dev headers** — per interpreter on Linux (see quick start step 3).
+- **Network** — first phcc index build or `--refresh` contacts PyPI.
+
+Parallel runs use per-env `COVERAGE_FILE` in `tox.ini` so `.coverage` files do not clash.
+
+## Helper scripts
+
+### `scripts/phcc_matrix.py`
+
+Builds and maintains the mapping from HA month → phcc version range → tox env name.
+
+| Command                                         | Purpose                                                                         |
+| ----------------------------------------------- | ------------------------------------------------------------------------------- |
+| `python scripts/phcc_matrix.py`                 | List tox envs and phcc spec for hacs.json .. latest PyPI (uses / updates index) |
+| `python scripts/phcc_matrix.py --refresh`       | Re-fetch all phcc metadata from PyPI                                            |
+| `python scripts/phcc_matrix.py --github-matrix` | JSON matrix for CI                                                              |
+
+**Index cache:** `.tox/phcc_version_index.json` (gitignored). Stores phcc → HA mappings and cached `Requires-Python` per HA release. First run or `--refresh` contacts PyPI; later runs are incremental.
+
+**`PHCC_INDEX_OFFLINE=1`:** use the on-disk index only (no PyPI list or metadata fetch). CI matrix jobs set this after downloading the index from **matrix-prep**.
+
+### `scripts/tox_ha_install.py`
+
+Tox `install_command` hook. For HA envs it installs `test-requirements.txt`, manifest requirements, phcc (which pins `homeassistant`), and `pycares>=4.0.0,<5` for 2025.x months when needed (aiodns compatibility).
+
+### `toxfile.py`
+
+Tox 4 plugin loaded from the repo root. Appends HA env names to `envlist` so `tox run-parallel` matches CI without a long static list in git. Python interpreters come from `basepython` factors in `tox.ini` (add a line when a new `py315` prefix appears).
+
+- `tox -e lint` — does not load the phcc index for env registration.
+- `tox -e py313-ha202510` — registers only the named HA env(s); does not enumerate the full matrix.
+- `tox -av` / `tox run-parallel` — discovers all HA envs via `list_tox_envs()` (may update the index).
+
+## GitHub Actions
+
+Workflow: `.github/workflows/ci.yaml`
+
+1. **lint** — `tox -e lint`
+2. **matrix-prep** — builds/updates `.tox/phcc_version_index.json` once, runs `--github-matrix`, uploads the index as a workflow artifact
+3. **homeassistant** — one job per matrix row; downloads the index artifact, sets `PHCC_INDEX_OFFLINE=1`, then `tox -e ${{ matrix.toxenv }}` (no per-job PyPI phcc indexing)
+
+Caches: pip wheels (per job, via `setup-python`); phcc index warm-start in **matrix-prep** only (`actions/cache` on `.tox/phcc_version_index.json`). Matrix jobs use the artifact from the same workflow run, not a separate index rebuild. Full tox venvs are **not** cached in CI.
+
+## Maintenance
+
+### Raise minimum supported HA (HACS)
+
+1. Update `hacs.json` → `"homeassistant"`.
+2. Commit `hacs.json`. CI and local tox pick up the new floor on the next run (no `tox.ini` edit).
+
+### New HA month released
+
+Usually **no manual edit**: max month comes from PyPI. After phcc publishes a release for that month, the next CI run and the next local `tox` invocation include it.
+
+### New Python for newer HA months
+
+When Home Assistant ships requiring a newer Python (e.g. 3.15), PyPI’s `Requires-Python` on that `homeassistant` wheel is read automatically. No cutoff constant to maintain.
+
+1. Add `py315: python3.15` under `[testenv]` `basepython` in `tox.ini` (tox matches the `py315` prefix in env names).
+2. Install that Python locally (and `python3.15-dev` on Linux if wheels build from source).
+3. CI `setup-python` uses the version from `--github-matrix` (`py315` → `3.15`).
+
+New env names (e.g. `py315-ha202607`) appear automatically once step 1 is in place.
+
+## Troubleshooting
+
+| Symptom                                                  | Likely cause                                                                                                             |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `pytest` not found / install skipped                     | Ensure `tox.ini` has `deps = -rtest-requirements.txt` and `package = skip`                                               |
+| `Python.h: No such file or directory` during install     | Install dev package for that env’s Python (`python3.13-dev`, `python3.14-dev`, …)                                        |
+| `Lingering task` after `test_reload`                     | Bridge must call `api.close()` on unload (`HubspaceBridge.async_reset`)                                                  |
+| One env fails in parallel with exit code 3, passes alone | Stale shared `.coverage`; fixed via per-env `COVERAGE_FILE` in `tox.ini`                                                 |
+| Very slow first tox run                                  | Building phcc index from PyPI; reuse `.tox/phcc_version_index.json`                                                      |
+| pip appears to hang                                      | Avoid unpinned phcc + separate `homeassistant==`; use `tox_ha_install` only                                              |
+| HA envs missing from `tox -av`                           | tox older than 4.29 or `toxfile.py` not loaded; upgrade tox and run from repo root                                       |
+| `tox -e lint` slow on first run                          | `tox -av` / `run-parallel` builds the phcc index; `tox -e lint` or `tox -e py313-ha…` alone avoids full matrix discovery |
+| PyPI unreachable / offline                               | Reuse `.tox/phcc_version_index.json` if present; build index once online. `--refresh` needs network                      |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -124,9 +124,9 @@ Workflow: `.github/workflows/ci.yaml`
 
 1. **lint** — `tox -e lint`
 2. **matrix-prep** — builds/updates `.tox/phcc_version_index.json` once, runs `--github-matrix`, uploads the index as a workflow artifact
-3. **homeassistant** — one job per matrix row; downloads the index artifact, sets `PHCC_INDEX_OFFLINE=1`, installs `tox>=4.29`, then `tox -e ${{ matrix.toxenv }}` (no per-job PyPI phcc indexing)
+3. **homeassistant** — one job per matrix row; downloads the index artifact, sets `PHCC_INDEX_OFFLINE=1`, then `tox -e ${{ matrix.toxenv }}` (no per-job PyPI phcc indexing)
 
-CI installs tox from `test-requirements.txt` in **lint** and `tox>=4.29,<6` in matrix jobs (tox alone is enough there; HA envs pull test deps via tox).
+CI installs `pip install -r test-requirements.txt` before tox in **lint** and **homeassistant** (ensures `tox>=4.29` matches `tox.ini`; HA envs still install test deps into the tox venv via `tox.ini`).
 
 Caches: pip wheels (per job, via `setup-python`); phcc index warm-start in **matrix-prep** only (`actions/cache` on `.tox/phcc_version_index.json`). Matrix jobs use the artifact from the same workflow run, not a separate index rebuild. Full tox venvs are **not** cached in CI.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-homeassistant
-aioafero>=6.2.0
-aiofiles>=24.1.0
-packaging>=25.0

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Tox/CI helpers (phcc matrix, HA install hook). Not an installable package."""

--- a/scripts/phcc_matrix.py
+++ b/scripts/phcc_matrix.py
@@ -139,9 +139,7 @@ def resolve_max_ha_month(versions: dict[str, str] | None = None) -> str:
     if versions:
         available = sorted({_ha_minor(v) for v in versions.values()}, key=_month_key)
         if available:
-            logger.info(
-                "using latest phcc-index month %s as max", available[-1]
-            )
+            logger.info("using latest phcc-index month %s as max", available[-1])
             return available[-1]
     raise LookupError(
         "Could not determine latest Home Assistant month (PyPI unreachable and no phcc index)"
@@ -428,9 +426,7 @@ def update_version_index_from_pypi(*, force: bool = False) -> VersionIndex:
                 total = len(todo)
                 for i, phcc_version in enumerate(todo, start=1):
                     if i == 1 or i % 25 == 0 or i == total:
-                        logger.info(
-                            "indexing phcc metadata (%d/%d)...", i, total
-                        )
+                        logger.info("indexing phcc metadata (%d/%d)...", i, total)
                     ha_version = _homeassistant_for_phcc(phcc_version)
                     if ha_version:
                         versions[phcc_version] = ha_version

--- a/scripts/phcc_matrix.py
+++ b/scripts/phcc_matrix.py
@@ -1,0 +1,540 @@
+"""Resolve pytest-homeassistant-custom-component (phcc) pins per Home Assistant month.
+
+phcc releases pin homeassistant==X.Y.Z. Tox env factors like ha202603 map to HA month
+2026.3. An on-disk version index is updated incrementally from PyPI (only new phcc
+releases are fetched). No manual --refresh unless you want to force a full rescan.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+import json
+import logging
+import os
+from pathlib import Path
+import re
+import sys
+from typing import TypedDict
+import urllib.request
+
+logger = logging.getLogger("phcc_matrix")
+
+if not logging.getLogger().handlers:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[%(name)s] %(message)s",
+        stream=sys.stderr,
+    )
+
+PHCC_PROJECT = "pytest-homeassistant-custom-component"
+PHCC_PYPI_JSON = f"https://pypi.org/pypi/{PHCC_PROJECT}/json"
+HA_PYPI_JSON = "https://pypi.org/pypi/homeassistant/json"
+HA_FACTOR_RE = re.compile(r"ha(\d{4,6})")
+TOX_PYTHON_TAG_RE = re.compile(r"^(py\d+)-")
+PHCC_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+HA_RELEASE_RE = re.compile(r"^(20\d{2})\.(\d+)\.\d+$")
+REQUIRES_PYTHON_MIN_RE = re.compile(r">=(\d+)\.(\d+)")
+
+ROOT = Path(__file__).resolve().parents[1]
+HACS_PATH = ROOT / "hacs.json"
+INDEX_PATH = Path(
+    os.environ.get("PHCC_INDEX_PATH", ROOT / ".tox" / "phcc_version_index.json")
+)
+
+
+def _index_offline_mode() -> bool:
+    """When set (e.g. CI matrix jobs), use the on-disk index only — no PyPI refresh."""
+    return os.environ.get("PHCC_INDEX_OFFLINE", "").lower() in {"1", "true", "yes"}
+
+
+class VersionIndex(TypedDict):
+    """On-disk phcc index payload."""
+
+    versions: dict[str, str]
+    ha_python_requires: dict[str, str]
+
+
+def _out(message: str) -> None:
+    """Write a line to stdout."""
+    sys.stdout.write(f"{message}\n")
+
+
+def _fetch_json(url: str, *, timeout: int) -> dict:
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        return json.load(response)
+
+
+def _fetch_optional_json(url: str, *, timeout: int) -> dict | None:
+    try:
+        return _fetch_json(url, timeout=timeout)
+    except OSError:
+        return None
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
+def _ha_version_key(version: str) -> tuple[int, ...]:
+    """Sort key for homeassistant calver (stable releases only for comparisons)."""
+    parts = version.split(".")
+    patch = parts[2] if len(parts) > 2 else "0"
+    if "b" in patch:
+        patch = patch.split("b", 1)[0] or "0"
+    return (int(parts[0]), int(parts[1]), int(patch))
+
+
+@dataclass(frozen=True)
+class MonthSpec:
+    """Resolved phcc install pin for one Home Assistant month."""
+
+    ha_month: str
+    phcc_spec: str
+    pycares_pin: bool
+    homeassistant: str
+
+
+def load_hacs_min_ha_month() -> str:
+    """Minimum HA version from hacs.json (integration support floor)."""
+    data = json.loads(HACS_PATH.read_text(encoding="utf-8"))
+    ha = data.get("homeassistant")
+    if not ha:
+        raise KeyError(f"{HACS_PATH} missing 'homeassistant'")
+    return ha
+
+
+def _month_key(ha_month: str) -> tuple[int, int]:
+    year, month = ha_month.split(".", 1)
+    return int(year), int(month)
+
+
+def fetch_latest_ha_month_from_pypi() -> str:
+    """Latest Home Assistant release month from PyPI (e.g. 2026.5)."""
+    project = _fetch_json(HA_PYPI_JSON, timeout=60)
+    latest_key: tuple[int, int] | None = None
+    latest_month: str | None = None
+    for version in project.get("releases", {}):
+        if "b" in version:
+            continue
+        match = HA_RELEASE_RE.match(version)
+        if not match:
+            continue
+        key = int(match.group(1)), int(match.group(2))
+        if latest_key is None or key > latest_key:
+            latest_key = key
+            latest_month = f"{key[0]}.{key[1]}"
+    if latest_month is None:
+        raise LookupError("No homeassistant calver releases found on PyPI")
+    return latest_month
+
+
+def resolve_max_ha_month(versions: dict[str, str] | None = None) -> str:
+    """Upper HA month from latest PyPI homeassistant release."""
+    if not _index_offline_mode():
+        try:
+            return fetch_latest_ha_month_from_pypi()
+        except OSError as err:
+            logger.warning("PyPI homeassistant lookup failed: %s", err)
+    if versions:
+        available = sorted({_ha_minor(v) for v in versions.values()}, key=_month_key)
+        if available:
+            logger.info(
+                "using latest phcc-index month %s as max", available[-1]
+            )
+            return available[-1]
+    raise LookupError(
+        "Could not determine latest Home Assistant month (PyPI unreachable and no phcc index)"
+    )
+
+
+def iter_ha_months(min_month: str, max_month: str) -> Iterator[str]:
+    """Yield HA months from min_month through max_month inclusive."""
+    year, month = _month_key(min_month)
+    y2, m2 = _month_key(max_month)
+    while (year, month) <= (y2, m2):
+        yield f"{year}.{month}"
+        month += 1
+        if month > 12:
+            year += 1
+            month = 1
+
+
+def ha_month_to_factor(ha_month: str) -> str:
+    """Tox ha factor suffix (e.g. 2025.7 -> 20257, 2026.3 -> 202603)."""
+    year, month = _month_key(ha_month)
+    if year >= 2026 and month < 10:
+        return f"{year}{month:02d}"
+    return f"{year}{month}"
+
+
+def _fetch_ha_python_requires(homeassistant_version: str) -> str | None:
+    """Requires-Python from PyPI for a homeassistant release (e.g. '>=3.14.0')."""
+    url = f"https://pypi.org/pypi/homeassistant/{homeassistant_version}/json"
+    project = _fetch_optional_json(url, timeout=30)
+    if project is None:
+        return None
+    return project.get("info", {}).get("requires_python")
+
+
+def _min_python_from_requires_python(requires_python: str) -> tuple[int, int]:
+    """Lower bound (major, minor) from a Requires-Python string."""
+    match = REQUIRES_PYTHON_MIN_RE.search(requires_python)
+    if not match:
+        raise ValueError(f"Cannot parse Requires-Python: {requires_python!r}")
+    return int(match.group(1)), int(match.group(2))
+
+
+def _latest_ha_version_for_month(ha_month: str, versions: dict[str, str]) -> str:
+    candidates = [ha for ha in versions.values() if _ha_minor(ha) == ha_month]
+    if not candidates:
+        raise LookupError(f"No homeassistant version indexed for HA month {ha_month}")
+    stable = [ha for ha in candidates if "b" not in ha]
+    return max(stable or candidates, key=_ha_version_key)
+
+
+def _python_tag_for_ha_month(
+    ha_month: str,
+    versions: dict[str, str],
+    ha_python_requires: dict[str, str],
+) -> str:
+    """Tox Python factor (py313, py314, …) from homeassistant Requires-Python on PyPI."""
+    ha_version = _latest_ha_version_for_month(ha_month, versions)
+    requires = ha_python_requires.get(ha_version)
+    if not requires:
+        requires = _fetch_ha_python_requires(ha_version)
+        if requires:
+            ha_python_requires[ha_version] = requires
+    if not requires:
+        raise LookupError(
+            f"No Requires-Python metadata for homeassistant=={ha_version} on PyPI"
+        )
+    major, minor = _min_python_from_requires_python(requires)
+    return f"py{major}{minor}"
+
+
+def ha_month_to_tox_env(
+    ha_month: str,
+    versions: dict[str, str],
+    ha_python_requires: dict[str, str],
+) -> str:
+    """Map an HA month to a tox environment name (e.g. 2026.3 -> py314-ha202603)."""
+    py_tag = _python_tag_for_ha_month(ha_month, versions, ha_python_requires)
+    return f"{py_tag}-ha{ha_month_to_factor(ha_month)}"
+
+
+def _python_tag_to_version(py_tag: str) -> str:
+    """Map tox factor py313 -> 3.13, py314 -> 3.14."""
+    if not py_tag.startswith("py") or len(py_tag) < 4:
+        raise ValueError(f"Invalid python tag: {py_tag!r}")
+    digits = py_tag[2:]
+    return f"{digits[0]}.{digits[1:]}"
+
+
+def tox_env_to_python_version(tox_env: str) -> str:
+    """Return setup-python version for a tox env (e.g. py314-ha202603 -> 3.14)."""
+    return _python_tag_to_version(_tox_python_tag_from_env(tox_env))
+
+
+def list_github_matrix_entries(
+    *, refresh: bool = False, require_phcc: bool = True
+) -> list[dict[str, str]]:
+    """GHA matrix rows: toxenv + python, derived from the tox env name."""
+    return [
+        {"toxenv": env, "python": tox_env_to_python_version(env)}
+        for env in list_tox_envs(refresh=refresh, require_phcc=require_phcc)
+    ]
+
+
+def load_full_index() -> VersionIndex:
+    """Phcc index: versions (phcc -> HA) and ha_python_requires (HA -> Requires-Python)."""
+    if INDEX_PATH.is_file():
+        data = json.loads(INDEX_PATH.read_text(encoding="utf-8"))
+        return {
+            "versions": data.get("versions", {}),
+            "ha_python_requires": data.get("ha_python_requires", {}),
+        }
+    return {"versions": {}, "ha_python_requires": {}}
+
+
+def list_tox_envs(*, refresh: bool = False, require_phcc: bool = True) -> list[str]:
+    """Tox env names from hacs.json min through latest testable HA month."""
+    min_month = load_hacs_min_ha_month()
+    index = update_version_index_from_pypi(force=refresh)
+    versions = index["versions"]
+    ha_python_requires = index["ha_python_requires"]
+    max_month = resolve_max_ha_month(versions)
+    if _month_key(max_month) < _month_key(min_month):
+        raise ValueError(
+            f"HA test max ({max_month}) is before hacs.json minimum ({min_month})"
+        )
+    months_with_phcc = {_ha_minor(v) for v in versions.values()}
+    envs: list[str] = []
+    for month in iter_ha_months(min_month, max_month):
+        if require_phcc and month not in months_with_phcc:
+            continue
+        envs.append(ha_month_to_tox_env(month, versions, ha_python_requires))
+    if not envs:
+        raise LookupError(
+            f"No phcc-backed HA months between {min_month} and {max_month}. "
+            "Run: python scripts/phcc_matrix.py --refresh"
+        )
+    return envs
+
+
+def _tox_python_tag_from_env(tox_env: str) -> str:
+    match = TOX_PYTHON_TAG_RE.match(tox_env)
+    if not match:
+        raise ValueError(f"Not a HA tox env name: {tox_env!r}")
+    return match.group(1)
+
+
+def parse_ha_month_from_env(env_name: str) -> str | None:
+    """Parse HA month from a tox env name (e.g. py313-ha202510 -> 2025.10)."""
+    match = HA_FACTOR_RE.search(env_name)
+    if not match:
+        return None
+    digits = match.group(1)
+    year = int(digits[:4])
+    month = int(digits[4:])
+    return f"{year}.{month}"
+
+
+def _ha_minor(homeassistant_version: str) -> str:
+    major, minor, *_ = homeassistant_version.split(".")
+    return f"{major}.{minor}"
+
+
+def _fetch_phcc_version_metadata(version: str) -> dict | None:
+    return _fetch_optional_json(
+        f"https://pypi.org/pypi/{PHCC_PROJECT}/{version}/json",
+        timeout=30,
+    )
+
+
+def _list_phcc_versions_on_pypi() -> list[str]:
+    project = _fetch_json(PHCC_PYPI_JSON, timeout=60)
+    versions = [v for v in project["releases"] if PHCC_VERSION_RE.match(v)]
+    return sorted(versions, key=_version_key)
+
+
+def _try_list_phcc_versions_on_pypi() -> list[str] | None:
+    """Return phcc release versions from PyPI, or None when offline/unreachable."""
+    try:
+        return _list_phcc_versions_on_pypi()
+    except OSError as err:
+        logger.warning("PyPI phcc lookup failed: %s", err)
+        return None
+
+
+def load_version_index() -> dict[str, str]:
+    """Phcc version -> homeassistant full version (e.g. 2026.3.4)."""
+    return load_full_index()["versions"]
+
+
+def _backfill_ha_python_requires(
+    versions: dict[str, str],
+    ha_python_requires: dict[str, str],
+    *,
+    min_month: str | None = None,
+    max_month: str | None = None,
+) -> None:
+    """Fetch Requires-Python from PyPI for homeassistant versions in the test range."""
+    ha_versions = set(versions.values())
+    if min_month is not None and max_month is not None:
+        months_in_range = set(iter_ha_months(min_month, max_month))
+        ha_versions = {ha for ha in ha_versions if _ha_minor(ha) in months_in_range}
+    for ha_version in sorted(ha_versions, key=_ha_version_key):
+        if ha_version in ha_python_requires:
+            continue
+        requires = _fetch_ha_python_requires(ha_version)
+        if requires:
+            ha_python_requires[ha_version] = requires
+
+
+def save_version_index(
+    versions: dict[str, str],
+    ha_python_requires: dict[str, str] | None = None,
+) -> None:
+    """Persist phcc index (and optional homeassistant Requires-Python cache)."""
+    INDEX_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if ha_python_requires is None:
+        ha_python_requires = load_full_index()["ha_python_requires"]
+    payload = {
+        "versions": dict(
+            sorted(versions.items(), key=lambda item: _version_key(item[0]))
+        ),
+        "ha_python_requires": dict(
+            sorted(
+                ha_python_requires.items(), key=lambda item: _ha_version_key(item[0])
+            )
+        ),
+    }
+    INDEX_PATH.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _homeassistant_for_phcc(version: str) -> str | None:
+    meta = _fetch_phcc_version_metadata(version)
+    if meta is None:
+        return None
+    requires = meta["info"].get("requires_dist") or []
+    ha_req = next((r for r in requires if r.startswith("homeassistant==")), None)
+    if not ha_req:
+        return None
+    return ha_req.split("==", 1)[1]
+
+
+def update_version_index_from_pypi(*, force: bool = False) -> VersionIndex:
+    """Fetch metadata only for phcc releases not already in the index."""
+    index = load_full_index()
+    cached_versions = index["versions"]
+    cached_requires = index["ha_python_requires"]
+    if force:
+        versions: dict[str, str] = {}
+        ha_python_requires: dict[str, str] = {}
+    else:
+        versions = dict(cached_versions)
+        ha_python_requires = dict(cached_requires)
+
+    if _index_offline_mode() and not force:
+        if not versions:
+            raise LookupError(
+                f"PHCC_INDEX_OFFLINE set but no index at {INDEX_PATH}. "
+                "Build the index in matrix-prep or run online once."
+            )
+        logger.info(
+            "using index only (%d phcc releases, PHCC_INDEX_OFFLINE)",
+            len(versions),
+        )
+    else:
+        pypi_versions = _try_list_phcc_versions_on_pypi()
+        if pypi_versions is None:
+            if force:
+                raise LookupError(
+                    "Cannot --refresh: PyPI unreachable (existing index left unchanged)"
+                )
+            if not versions:
+                raise LookupError(
+                    f"PyPI unreachable and no phcc index at {INDEX_PATH}. "
+                    "Run once online to build the index."
+                )
+            logger.info(
+                "using cached index (%d phcc releases, PyPI offline)",
+                len(versions),
+            )
+        else:
+            todo = [v for v in pypi_versions if force or v not in versions]
+            if todo:
+                total = len(todo)
+                for i, phcc_version in enumerate(todo, start=1):
+                    if i == 1 or i % 25 == 0 or i == total:
+                        logger.info(
+                            "indexing phcc metadata (%d/%d)...", i, total
+                        )
+                    ha_version = _homeassistant_for_phcc(phcc_version)
+                    if ha_version:
+                        versions[phcc_version] = ha_version
+        min_month = load_hacs_min_ha_month()
+        max_month = resolve_max_ha_month(versions)
+        _backfill_ha_python_requires(
+            versions, ha_python_requires, min_month=min_month, max_month=max_month
+        )
+    save_version_index(versions, ha_python_requires)
+    return {"versions": versions, "ha_python_requires": ha_python_requires}
+
+
+def _month_spec_from_index(ha_month: str, versions: dict[str, str]) -> MonthSpec | None:
+    entries: list[tuple[tuple[int, ...], str, str]] = []
+    for phcc_version, ha_version in versions.items():
+        if _ha_minor(ha_version) != ha_month:
+            continue
+        entries.append((_version_key(phcc_version), phcc_version, ha_version))
+    if not entries:
+        return None
+
+    entries.sort(key=lambda item: item[0])
+    all_phcc = sorted(_version_key(v) for v in versions)
+    lo_ver = entries[0][1]
+    hi_pv = entries[-1][0]
+    hi_ha = entries[-1][2]
+    idx = all_phcc.index(hi_pv)
+    if idx + 1 < len(all_phcc):
+        upper = ".".join(str(p) for p in all_phcc[idx + 1])
+        spec = f"{PHCC_PROJECT}>={lo_ver},<{upper}"
+    else:
+        spec = f"{PHCC_PROJECT}>={lo_ver}"
+    year = int(ha_month.split(".")[0])
+    return MonthSpec(
+        ha_month=ha_month,
+        phcc_spec=spec,
+        pycares_pin=year == 2025,
+        homeassistant=hi_ha,
+    )
+
+
+def get_month_spec(ha_month: str, *, refresh: bool = False) -> MonthSpec:
+    """Resolve install spec for an HA month; updates PyPI index on demand."""
+    versions = update_version_index_from_pypi(force=refresh)["versions"]
+    spec = _month_spec_from_index(ha_month, versions)
+    if spec is not None:
+        return spec
+
+    raise LookupError(
+        f"No {PHCC_PROJECT} release found for Home Assistant {ha_month}. "
+        "Check the tox factor (e.g. ha202603) or run: python scripts/phcc_matrix.py --refresh"
+    )
+
+
+def main() -> None:
+    """CLI entry point."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Re-fetch all phcc version metadata from PyPI",
+    )
+    parser.add_argument(
+        "--github-matrix",
+        action="store_true",
+        help="Print GHA matrix JSON [{toxenv, python}, ...] (min from hacs.json)",
+    )
+    parser.add_argument(
+        "ha_month",
+        nargs="?",
+        help="HA month like 2026.3 (optional; prints derived matrix if omitted)",
+    )
+    args = parser.parse_args()
+
+    if args.github_matrix:
+        _out(json.dumps(list_github_matrix_entries(refresh=args.refresh)))
+        return
+
+    if not args.ha_month:
+        envs = list_tox_envs(refresh=args.refresh)
+        versions = load_version_index()
+        _out(f"Index: {INDEX_PATH} ({len(versions)} phcc releases)")
+        _out(
+            f"Test range: {load_hacs_min_ha_month()} .. "
+            f"{resolve_max_ha_month(versions)} ({len(envs)} tox envs)"
+        )
+        for env in envs:
+            month = parse_ha_month_from_env(env)
+            if month is None:
+                continue
+            spec = _month_spec_from_index(month, versions)
+            if spec:
+                _out(f"  {env}: {spec.phcc_spec} (HA {spec.homeassistant})")
+        return
+
+    spec = get_month_spec(args.ha_month, refresh=args.refresh)
+    versions = load_version_index()
+    _out(f"Index: {INDEX_PATH} ({len(versions)} phcc releases)")
+    _out(spec.phcc_spec)
+    if spec.pycares_pin:
+        _out("pycares>=4.0.0,<5")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tox_ha_install.py
+++ b/scripts/tox_ha_install.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Tox install_command: install deps + phcc for the HA month implied by {envname}."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+import subprocess
+import sys
+
+_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS = Path(__file__).resolve().parent
+MANIFEST_PATH = _ROOT / "custom_components" / "hubspace" / "manifest.json"
+
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from phcc_matrix import get_month_spec, parse_ha_month_from_env  # noqa: E402
+
+logger = logging.getLogger("tox_ha_install")
+
+
+def load_manifest_requirements() -> list[str]:
+    """Integration runtime deps from manifest.json (same source HACS uses)."""
+    data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    requirements = data.get("requirements")
+    if not requirements:
+        raise KeyError(f"{MANIFEST_PATH} missing 'requirements'")
+    return list(requirements)
+
+
+def main() -> int:
+    """Tox install_command entry point."""
+    # tox 4: install_command = python .../tox_ha_install.py {envname} {opts} {packages}
+    argv = sys.argv[1:]
+    if not argv:
+        logger.error("usage: tox_ha_install.py <envname> [pip opts and packages...]")
+        return 2
+
+    env_name = argv[0]
+    pip_args = argv[1:]
+
+    ha_month = parse_ha_month_from_env(env_name)
+    if ha_month is None or "--no-deps" in pip_args:
+        cmd = [sys.executable, "-I", "-m", "pip", "install", *pip_args]
+        return subprocess.call(cmd)
+
+    spec = get_month_spec(ha_month)
+    packages = [
+        *load_manifest_requirements(),
+        spec.phcc_spec,
+    ]
+    if spec.pycares_pin:
+        packages.append("pycares>=4.0.0,<5")
+
+    cmd = [
+        sys.executable,
+        "-I",
+        "-m",
+        "pip",
+        "install",
+        *pip_args,
+        *packages,
+    ]
+    logger.info("%s -> HA %s (%s)", env_name, ha_month, spec.homeassistant)
+    logger.info("%s", spec.phcc_spec)
+    return subprocess.call(cmd)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,4 @@ pytest-mock
 pytest-asyncio
 responses
 pre-commit
-pytest-homeassistant-custom-component
-tox
-pycares<5
+tox>=4.29

--- a/tox.ini
+++ b/tox.ini
@@ -1,33 +1,30 @@
 [tox]
-envlist = lint, py313-ha{20257,20258,20259,202510}
+minversion = 4.29
+envlist = lint
+# HA envs are added at runtime by toxfile.py from hacs.json + scripts/phcc_matrix.py
+# (same range as CI --github-matrix). List envs: tox -av
 
 [testenv]
+# See docs/testing.md for the full testing/CI guide (not in README — HACS displays README only).
+# Deps: manifest.json (integration) + phcc (HA) via scripts/tox_ha_install.py; test tools below.
+package = skip
 deps =
-    -rrequirements.txt
     -rtest-requirements.txt
-    homeassistant=={env:HA_VERSION}
+setenv =
+    COVERAGE_FILE = {env_dir}{/}.coverage
+basepython =
+    py314: python3.14
+    py313: python3.13
+install_command =
+    python {toxinidir}/scripts/tox_ha_install.py {envname} {opts} {packages}
 commands =
-    pytest
+    pytest {posargs}
 
 [testenv:lint]
+description = pre-commit (ruff, format, yaml, etc.)
 skip_install = true
+basepython = python3.13
 deps =
     pre-commit
 commands =
     pre-commit run --all-files
-
-[testenv:py313-ha20257]
-basepython = python3.13
-setenv = HA_VERSION=2025.7
-
-[testenv:py313-ha20258]
-basepython = python3.13
-setenv = HA_VERSION=2025.8
-
-[testenv:py313-ha20259]
-basepython = python3.13
-setenv = HA_VERSION=2025.9
-
-[testenv:py313-ha202510]
-basepython = python3.13
-setenv = HA_VERSION=2025.10

--- a/toxfile.py
+++ b/toxfile.py
@@ -1,0 +1,94 @@
+"""Register HA tox envs from hacs.json (same logic as CI matrix-prep).
+
+See docs/testing.md. Requires tox >= 4.29.
+"""
+
+from __future__ import annotations
+
+import functools
+from pathlib import Path
+import sys
+from typing import cast
+
+from tox.config.loader.memory import MemoryLoader
+from tox.config.types import EnvList
+from tox.plugin import impl
+
+_ROOT = Path(__file__).resolve().parent
+if str(_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(_ROOT / "scripts"))
+
+from phcc_matrix import (  # noqa: E402
+    TOX_PYTHON_TAG_RE,
+    list_tox_envs,
+    parse_ha_month_from_env,
+    tox_env_to_python_version,
+)
+
+
+def _cli_selections() -> list[str]:
+    """Tox env names passed via -e / --env on the command line."""
+    args = sys.argv[1:]
+    selections: list[str] = []
+
+    for i, arg in enumerate(args):
+        if arg in {"-e", "--env"}:
+            if i + 1 < len(args):
+                selections.extend(args[i + 1].split(","))
+            continue
+        if arg.startswith("--env="):
+            selections.extend(arg.split("=", 1)[1].split(","))
+
+    return [part for part in selections if part]
+
+
+def _lint_only_cli() -> bool:
+    """Return whether tox was invoked with only ``-e lint`` (skip phcc index)."""
+    selections = _cli_selections()
+    return bool(selections) and all(part == "lint" for part in selections)
+
+
+def _explicit_ha_envs_cli() -> tuple[str, ...] | None:
+    """HA env names from -e when set; None means discover full matrix (tox -av / run-parallel)."""
+    selections = _cli_selections()
+    if not selections or any(part == "lint" for part in selections):
+        return None
+    if not all(TOX_PYTHON_TAG_RE.match(part) for part in selections):
+        return None
+    return tuple(selections)
+
+
+@functools.lru_cache
+def _ha_tox_envs() -> tuple[str, ...]:
+    return tuple(list_tox_envs())
+
+
+@impl
+def tox_add_core_config(core_conf, state):
+    """Append HA envs to envlist so run-parallel picks them up (not only tox -e)."""
+    if _lint_only_cli():
+        return
+    explicit = _explicit_ha_envs_cli()
+    names = explicit if explicit is not None else _ha_tox_envs()
+    env_list = cast(EnvList, core_conf["env_list"])
+    for name in names:
+        if name not in env_list.envs:
+            env_list.envs.append(name)
+
+
+@impl
+def tox_add_env_config(env_conf, state):
+    """Set a human-readable description for each HA month env."""
+    name = env_conf.env_name
+    if name == "lint" or not TOX_PYTHON_TAG_RE.match(name):
+        return
+    ha_month = parse_ha_month_from_env(name)
+    if ha_month is None:
+        return
+    python_version = tox_env_to_python_version(name)
+    env_conf.loaders.insert(
+        0,
+        MemoryLoader(
+            description=f"Integration tests on Home Assistant {ha_month} (Python {python_version})"
+        ),
+    )

--- a/toxfile.py
+++ b/toxfile.py
@@ -51,11 +51,14 @@ def _lint_only_cli() -> bool:
 def _explicit_ha_envs_cli() -> tuple[str, ...] | None:
     """HA env names from -e when set; None means discover full matrix (tox -av / run-parallel)."""
     selections = _cli_selections()
-    if not selections or any(part == "lint" for part in selections):
+    if not selections:
         return None
-    if not all(TOX_PYTHON_TAG_RE.match(part) for part in selections):
+    ha_envs = [part for part in selections if part != "lint"]
+    if not ha_envs:
         return None
-    return tuple(selections)
+    if not all(TOX_PYTHON_TAG_RE.match(part) for part in ha_envs):
+        return None
+    return tuple(ha_envs)
 
 
 @functools.lru_cache


### PR DESCRIPTION
Drive test months, phcc pins, and Python versions from hacs.json and PyPI (Requires-Python). toxfile.py registers the same envs locally as CI --github-matrix, without maintaining a static tox envlist. Parallel GHA jobs cache only the phcc index and pip wheels; manifest-based installs replace requirements.txt. Add testing docs and close aioafero on unload.

Remove legacy --sync-tox-ini tooling, lint scripts/ in pre-commit, skip phcc indexing for tox -e lint, and show HA month descriptions in tox list.