### PR TITLE
Fix climate temp units reverting after poll (#231).

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ are as follows:
 
 - 6.0.2
 
-  - Fix climate temperatures reverting to Celsius after polling by bumping
-    aioafero to 7.0.6 ([#231](https://github.com/jdeath/Hubspace-Homeassistant/issues/231))
+  - Fix climate temperatures reverting to Celsius after polling ([#231](https://github.com/jdeath/Hubspace-Homeassistant/issues/231)).
+    Temporarily installs `aioafero` from git `fix/unit-polling` (not PyPI) so the
+    Fahrenheit poll fix can be validated before a library release.
 
 - 6.0.1
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ are as follows:
 
 ## Changelog
 
+- 6.0.2
+
+  - Fix climate temperatures reverting to Celsius after polling by bumping
+    aioafero to 7.0.6 ([#231](https://github.com/jdeath/Hubspace-Homeassistant/issues/231))
+
 - 6.0.1
 
   - Fix split lights not being controllable

--- a/custom_components/hubspace/manifest.json
+++ b/custom_components/hubspace/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jdeath/Hubspace-Homeassistant/issues",
   "loggers": ["aioafero"],
-  "requirements": ["aioafero==7.0.4", "aiofiles", "packaging"],
+  "requirements": ["aioafero==7.0.6", "aiofiles", "packaging"],
   "single_config_entry": true,
-  "version": "6.0.1"
+  "version": "6.0.2"
 }

--- a/custom_components/hubspace/manifest.json
+++ b/custom_components/hubspace/manifest.json
@@ -9,7 +9,11 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jdeath/Hubspace-Homeassistant/issues",
   "loggers": ["aioafero"],
-  "requirements": ["aioafero==7.0.6", "aiofiles", "packaging"],
+  "requirements": [
+    "aioafero@git+https://github.com/Expl0dingBanana/aioafero.git@fix/unit-polling",
+    "aiofiles",
+    "packaging"
+  ],
   "single_config_entry": true,
   "version": "6.0.2"
 }


### PR DESCRIPTION
Bump aioafero to 7.0.6 so device-state polls send units=fahrenheit, matching discovery.